### PR TITLE
v0.4.0: DevOps agents + agent executions view (list & graph)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /bin/app/
 /bin/bin/
 /bin/domain/
+/bin/lib/
 /bin/cli.js
 
 # Testing and Coverage

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ---
 
-[![Version](https://img.shields.io/badge/Version-0.3.0-blue.svg)](https://github.com/dmux/speckit-assistant)
+[![Version](https://img.shields.io/badge/Version-0.4.0-blue.svg)](https://github.com/dmux/speckit-assistant)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Coverage Status](https://img.shields.io/badge/Coverage-99.44%25-brightgreen.svg)](https://github.com/dmux/speckit-assistant)
 [![Node Version](https://img.shields.io/badge/Node-%3E%3D%2018.0.0-blue.svg)](https://nodejs.org)
@@ -59,8 +59,12 @@ SpecKit Assistant acts as the **Visual Dashboard** and **Command-Line Interface*
 ## ✨ Key Features
 
 * 🎨 **Premium UI/UX**: High-fidelity dark and light themes (light by default) styled with a sleek, minimalist Vercel aesthetic.
-* 🧭 **Full-Width Sectioned Layout**: Top-level sections separate responsibilities — **Workflow**, **Agents**, and **MCP Tools** — each using the full width of the screen.
+* 🧭 **Full-Width Sectioned Layout**: Top-level sections separate responsibilities — **Workflow**, **Agents**, **MCP Tools**, and **Extensions** — each using the full width of the screen.
 * 🗺️ **Interactive ReactFlow DAG Map**: Visualizes the dependencies and status of every feature's development lifecycle.
+* 📡 **Agent Executions View**: A third Workflow view (next to Kanban / DAG) that tracks **every** agent run — phases, review personas, and DevOps agents — with live status, start time, duration, cost, tokens, and exit code, drillable to each run's saved log. Includes an **Obsidian-style force-directed graph** (agent/feature nodes, edges weighted by run frequency) that can be maximized full-screen. Backed by an append-only execution history that survives reloads.
+* 🚀 **DevOps Agents (on-demand)**: A profile of operational agents — **Deploy**, post-deploy **Monitor**, and **Troubleshoot** — run on demand from the Executions view, backed by the bundled `spec-kit-devops` extension.
+* 🧩 **Extension Manager**: Install and manage spec-kit extensions from the UI — one-click bundled installs (Review Personas, Specification Agents, DevOps Agents), community installs via GitHub ZIP/URL, and a one-click **`specify` CLI installer** (venv-first, from the spec-kit GitHub source — no `git` required).
+* 🧑‍⚖️ **Specification & Review Agents**: Spec-phase agents (Product Owner, Architecture, Refinement, Consolidate) wired as `after_specify` hooks, plus a sequential implementation **review gate** (QA, Code Review, Security, Tech Lead).
 * 📋 **Drag-and-Drop Kanban Board**: Progress features forward (auto-approving intermediate steps and launching agents) or roll them back (marking downstream files as stale) by simple drag-and-drop.
 * 🤖 **Agent Management (YAML)**: Create, edit, and persist multiple CLI agent profiles centrally in `.specify/agents.yaml`; the active agent drives every workflow run. Supports Anthropic's **Claude CLI**, Google's **Gemini CLI**, **GitHub Copilot CLI**, **OpenAI Codex**, or custom CLI wrappers.
 * 🔌 **Agnostic MCP Tools**: Define **Model Context Protocol** servers once, assign them per agent, and apply them to each CLI's *native* config — Claude `.mcp.json`, Gemini `~/.gemini/settings.json`, Codex `~/.codex/config.toml` — with safe read-merge-write (and `.bak` backups).
@@ -245,15 +249,21 @@ my-project/
 │   ├── agents.yaml             # Persisted CLI agent profiles + active agent
 │   ├── mcp.yaml                # Central MCP server definitions
 │   ├── personas-config.json    # Review-gate persona configuration
+│   ├── spec-agents.yaml        # Specification-phase agent roster
+│   ├── devops-agents.yaml      # DevOps agent roster (deploy/monitor/troubleshoot)
+│   ├── extensions/             # Installed spec-kit extensions (.registry + each extension)
 │   └── .runtime/
-│       └── workflow-state.json # Internal workflow cache (automatically managed)
+│       ├── workflow-state.json # Internal workflow cache (automatically managed)
+│       ├── executions.jsonl    # Append-only agent execution history
+│       └── logs/               # Captured per-run output logs
 └── specs/
     └── 001-user-authentication/
         ├── spec.md             # Feature requirements
         ├── plan.md             # Implementation strategy
         ├── checklist.md        # — or a checklists/ directory of multiple .md files
         ├── tasks.md            # Actionable checklists
-        └── reviews/            # Persona review reports (qa.md, security.md, ...)
+        ├── reviews/            # Persona review reports (qa.md, security.md, ...)
+        └── devops/             # DevOps agent reports (deploy.md, monitor.md, ...)
 ```
 
 ---

--- a/extensions/spec-kit-devops/README.md
+++ b/extensions/spec-kit-devops/README.md
@@ -1,0 +1,32 @@
+# Spec Kit DevOps Agents
+
+A Spec Kit extension that adds **operational (DevOps) agents** you run **on demand**
+from the speckit-assistant **Executions** view — after the implementation gate is
+approved. Unlike the review personas and specification agents, these are not wired as
+lifecycle hooks; you trigger them explicitly.
+
+## Commands
+
+| Command | Agent | Report written to |
+| --- | --- | --- |
+| `/speckit.devops.deploy` | Deploy / Release Engineer | `specs/<feature>/devops/deploy.md` |
+| `/speckit.devops.monitor` | Post-deploy Monitoring (SRE) | `specs/<feature>/devops/monitor.md` |
+| `/speckit.devops.troubleshoot` | Incident Troubleshooting | `specs/<feature>/devops/troubleshoot.md` |
+
+## The `STATUS:` contract
+
+Each command ends its report with a single status line (e.g. `STATUS: OK`,
+`STATUS: DEGRADED`, `STATUS: FAILED`, `STATUS: RESOLVED`). speckit-assistant surfaces
+the run result; it falls back to the process exit code if the marker is absent.
+
+## Installation
+
+Install into a Spec Kit workspace like any other extension (or one click in the
+speckit-assistant **Extensions** panel):
+
+```bash
+specify extension add --dev /path/to/spec-kit-devops
+```
+
+Per-agent model and system-prompt overrides are configured in the speckit-assistant
+**Agents → DevOps** panel and passed to the agent CLI at run time.

--- a/extensions/spec-kit-devops/commands/deploy.md
+++ b/extensions/spec-kit-devops/commands/deploy.md
@@ -1,0 +1,33 @@
+---
+description: "Deploy agent — ships the approved implementation and verifies the release."
+---
+
+# DevOps Agent: Deploy
+
+You are an experienced **DevOps/Release Engineer** responsible for deploying an
+approved feature implementation.
+
+## Context
+The feature directory is: `$ARGUMENTS` (e.g. `specs/001-my-feature`). It may be empty
+for a workspace-wide deploy.
+
+## Steps
+1. Read `$ARGUMENTS/plan.md` and `$ARGUMENTS/tasks.md` (when present) to understand
+   what is being shipped, plus any deployment notes in the repo (CI config, Dockerfile,
+   `vercel.json`/`vercel.ts`, infra manifests).
+2. Determine the appropriate deploy command(s) for this project and environment. Prefer
+   the project's documented release path. Do **not** invent destructive operations.
+3. Execute the deploy (or, if you cannot safely deploy, output the exact commands a
+   human should run and why).
+4. Verify the release: confirm the new version is live, run any smoke checks, and note
+   the deployed URL/version.
+
+## Output
+Write your report to `$ARGUMENTS/devops/deploy.md` (create the folder if needed) with:
+- **What was deployed** (version/commit, environment, URL).
+- **Steps taken** and their results.
+- **Verification** (smoke checks, health).
+- **Rollback** instructions.
+
+End the report with a single line `STATUS: OK` on success or `STATUS: FAILED` if the
+deploy did not complete.

--- a/extensions/spec-kit-devops/commands/monitor.md
+++ b/extensions/spec-kit-devops/commands/monitor.md
@@ -1,0 +1,30 @@
+---
+description: "Monitoring agent — inspects post-deploy health, metrics and logs."
+---
+
+# DevOps Agent: Monitor
+
+You are an experienced **Site Reliability Engineer** performing a post-deploy health
+check of a recently shipped feature.
+
+## Context
+The feature directory is: `$ARGUMENTS` (e.g. `specs/001-my-feature`). It may be empty
+for a workspace-wide check.
+
+## Steps
+1. Identify the live deployment (read `$ARGUMENTS/devops/deploy.md` if present for the
+   URL/version, otherwise infer from the project config).
+2. Inspect post-deploy health: availability of key endpoints, error rates, latency,
+   recent logs, and any alerting signals you can reach. Use the project's observability
+   tooling/CLIs where available.
+3. Compare against expected/baseline behaviour and the feature's acceptance criteria in
+   `$ARGUMENTS/spec.md`.
+
+## Output
+Write your report to `$ARGUMENTS/devops/monitor.md` (create the folder if needed) with:
+- **Health summary** (up/degraded/down) per checked surface.
+- **Key metrics** observed (error rate, latency, traffic) with timestamps.
+- **Anomalies** and suspected causes.
+- **Recommended follow-ups** (each with a concrete next action).
+
+End the report with a single line `STATUS: OK`, `STATUS: DEGRADED`, or `STATUS: FAILED`.

--- a/extensions/spec-kit-devops/commands/troubleshoot.md
+++ b/extensions/spec-kit-devops/commands/troubleshoot.md
@@ -1,0 +1,30 @@
+---
+description: "Troubleshooting agent — diagnoses incidents and proposes remediation."
+---
+
+# DevOps Agent: Troubleshoot
+
+You are an experienced **Incident Responder** diagnosing a problem with a deployed
+feature.
+
+## Context
+The feature directory is: `$ARGUMENTS` (e.g. `specs/001-my-feature`). It may be empty
+for a workspace-wide investigation.
+
+## Steps
+1. Gather the symptoms: read `$ARGUMENTS/devops/monitor.md` if present, recent logs,
+   error traces, and the latest deploy notes in `$ARGUMENTS/devops/deploy.md`.
+2. Form hypotheses and investigate methodically — narrow from symptom to root cause.
+   Reproduce locally when possible. Do **not** apply risky changes to production without
+   stating the risk.
+3. Identify the root cause and the smallest safe remediation (fix, config change, or
+   rollback).
+
+## Output
+Write your report to `$ARGUMENTS/devops/troubleshoot.md` (create the folder if needed) with:
+- **Incident summary** and impact.
+- **Investigation timeline** (what you checked and found).
+- **Root cause** (or the leading hypothesis if unconfirmed).
+- **Remediation** — concrete steps, plus a rollback option.
+
+End the report with a single line `STATUS: RESOLVED`, `STATUS: MITIGATED`, or `STATUS: FAILED`.

--- a/extensions/spec-kit-devops/extension.yml
+++ b/extensions/spec-kit-devops/extension.yml
@@ -1,0 +1,30 @@
+schema_version: "1.0"
+
+extension:
+  id: "devops"
+  name: "Spec Kit DevOps Agents"
+  version: "1.0.0"
+  description: "Operational sub-agents run on demand: Deploy, post-deploy Monitoring, and Troubleshooting."
+  author: "speckit-assistant"
+  repository: "https://github.com/dmux/speckit-assistant"
+  license: "MIT"
+
+requires:
+  speckit_version: ">=0.1.0"
+
+# Commands are invoked on demand from the speckit-assistant Executions view — they
+# are NOT wired as lifecycle hooks (no `hooks:` block). The command namespace must
+# equal the extension id (speckit.<id>.<command>).
+provides:
+  commands:
+    - name: "speckit.devops.deploy"
+      file: "commands/deploy.md"
+      description: "Deploy agent: ships the approved implementation and verifies the release."
+    - name: "speckit.devops.monitor"
+      file: "commands/monitor.md"
+      description: "Monitoring agent: inspects post-deploy health, metrics and logs."
+    - name: "speckit.devops.troubleshoot"
+      file: "commands/troubleshoot.md"
+      description: "Troubleshooting agent: diagnoses incidents and proposes remediation."
+
+tags: ["devops", "deploy", "monitoring", "troubleshooting", "operations"]

--- a/extensions/spec-kit-personas/README.md
+++ b/extensions/spec-kit-personas/README.md
@@ -8,10 +8,10 @@ QA → Code Review → Security → **Tech Lead** (final sign-off) — each as i
 
 | Command | Persona | Report written to |
 | --- | --- | --- |
-| `/speckit.review.qa` | QA Engineer | `specs/<feature>/reviews/qa.md` |
-| `/speckit.review.code` | Senior Code Reviewer | `specs/<feature>/reviews/code-review.md` |
-| `/speckit.review.security` | Security Engineer | `specs/<feature>/reviews/security.md` |
-| `/speckit.review.techlead` | Tech Lead | `specs/<feature>/reviews/tech-lead.md` |
+| `/speckit.personas.qa` | QA Engineer | `specs/<feature>/reviews/qa.md` |
+| `/speckit.personas.code` | Senior Code Reviewer | `specs/<feature>/reviews/code-review.md` |
+| `/speckit.personas.security` | Security Engineer | `specs/<feature>/reviews/security.md` |
+| `/speckit.personas.techlead` | Tech Lead | `specs/<feature>/reviews/tech-lead.md` |
 
 ## The `VERDICT:` contract
 

--- a/extensions/spec-kit-personas/extension.yml
+++ b/extensions/spec-kit-personas/extension.yml
@@ -14,16 +14,16 @@ requires:
 
 provides:
   commands:
-    - name: "speckit.review.qa"
+    - name: "speckit.personas.qa"
       file: "commands/qa.md"
       description: "QA persona: verifies the implementation against the spec and tasks."
-    - name: "speckit.review.code"
+    - name: "speckit.personas.code"
       file: "commands/code.md"
       description: "Code Review persona: reviews code quality, structure and maintainability."
-    - name: "speckit.review.security"
+    - name: "speckit.personas.security"
       file: "commands/security.md"
       description: "Security persona: audits the change for security issues."
-    - name: "speckit.review.techlead"
+    - name: "speckit.personas.techlead"
       file: "commands/techlead.md"
       description: "Tech Lead persona: aggregates the other reviews and signs off."
 

--- a/extensions/spec-kit-spec-agents/extension.yml
+++ b/extensions/spec-kit-spec-agents/extension.yml
@@ -14,16 +14,16 @@ requires:
 
 provides:
   commands:
-    - name: "speckit.spec.po"
+    - name: "speckit.spec-agents.po"
       file: "commands/po.md"
       description: "Product Owner agent: business value, scope and acceptance criteria."
-    - name: "speckit.spec.architecture"
+    - name: "speckit.spec-agents.architecture"
       file: "commands/architecture.md"
       description: "Architecture agent: technical risks, non-functional requirements and constraints."
-    - name: "speckit.spec.refine"
+    - name: "speckit.spec-agents.refine"
       file: "commands/refine.md"
       description: "Technical Refinement agent: requirement clarity, ambiguities and testability."
-    - name: "speckit.spec.consolidate"
+    - name: "speckit.spec-agents.consolidate"
       file: "commands/consolidate.md"
       description: "Consolidate lead: merges the spec-reviews contributions into spec.md."
 
@@ -33,25 +33,25 @@ hooks:
   after_specify:
     - id: spec-po
       extension: "spec-agents"
-      command: "speckit.spec.po"
+      command: "speckit.spec-agents.po"
       optional: true
       priority: 10
       description: "Product Owner review of the specification."
     - id: spec-architecture
       extension: "spec-agents"
-      command: "speckit.spec.architecture"
+      command: "speckit.spec-agents.architecture"
       optional: true
       priority: 20
       description: "Architecture review of the specification."
     - id: spec-refine
       extension: "spec-agents"
-      command: "speckit.spec.refine"
+      command: "speckit.spec-agents.refine"
       optional: true
       priority: 30
       description: "Technical refinement of the specification."
     - id: spec-consolidate
       extension: "spec-agents"
-      command: "speckit.spec.consolidate"
+      command: "speckit.spec-agents.consolidate"
       optional: true
       priority: 90
       description: "Consolidate the contributions into spec.md."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speckit-assistant",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Visual orchestrator for Spec-Driven Development (SDD) — Next.js, ReactFlow and Hexagonal Architecture",
   "main": "dist/index.js",
   "bin": {
@@ -48,6 +48,7 @@
     "chokidar": "^5.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "d3-force": "^3.0.0",
     "js-yaml": "^4.2.0",
     "lucide-react": "^0.468.0",
     "next": "^15.1.0",
@@ -63,6 +64,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
+    "@types/d3-force": "^3.0.10",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.17.9",
     "@types/react": "^19.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      d3-force:
+        specifier: ^3.0.0
+        version: 3.0.0
       js-yaml:
         specifier: ^4.2.0
         version: 4.2.0
@@ -66,6 +69,9 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/d3-force':
+        specifier: ^3.0.10
+        version: 3.0.10
       '@types/js-yaml':
         specifier: ^4.0.9
         version: 4.0.9
@@ -740,6 +746,9 @@ packages:
   '@types/d3-drag@3.0.7':
     resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
 
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
   '@types/d3-interpolate@3.0.4':
     resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
 
@@ -1032,8 +1041,16 @@ packages:
     resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
     engines: {node: '>=12'}
 
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
   d3-interpolate@3.0.1:
     resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
     engines: {node: '>=12'}
 
   d3-selection@3.0.0:
@@ -2381,6 +2398,8 @@ snapshots:
     dependencies:
       '@types/d3-selection': 3.0.11
 
+  '@types/d3-force@3.0.10': {}
+
   '@types/d3-interpolate@3.0.4':
     dependencies:
       '@types/d3-color': 3.1.3
@@ -2675,9 +2694,17 @@ snapshots:
 
   d3-ease@3.0.1: {}
 
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
   d3-interpolate@3.0.1:
     dependencies:
       d3-color: 3.1.0
+
+  d3-quadtree@3.0.1: {}
 
   d3-selection@3.0.0: {}
 

--- a/src/adapters/di.ts
+++ b/src/adapters/di.ts
@@ -3,16 +3,20 @@ import { ProcessAgentRunner } from './secondary/agent/ProcessAgentRunner';
 import { FSAgentRepository } from './secondary/fs/FSAgentRepository';
 import { FSMcpConfig } from './secondary/fs/FSMcpConfig';
 import { FSSpecAgentRepository } from './secondary/fs/FSSpecAgentRepository';
+import { FSDevOpsAgentRepository } from './secondary/fs/FSDevOpsAgentRepository';
 import { FSExtensionRepository } from './secondary/fs/FSExtensionRepository';
+import { FSExecutionHistory } from './secondary/fs/FSExecutionHistory';
 import { ProcessSpecifyRunner } from './secondary/cli/ProcessSpecifyRunner';
 import { WorkflowService } from '../domain/services/WorkflowService';
 
 const workspaceRepo = new FSWorkspaceRepository();
 const agentRunner = new ProcessAgentRunner();
 
-export const workflowService = new WorkflowService(workspaceRepo, agentRunner);
+export const executionHistory = new FSExecutionHistory();
+export const workflowService = new WorkflowService(workspaceRepo, agentRunner, executionHistory);
 export const agentRepository = new FSAgentRepository();
 export const mcpConfig = new FSMcpConfig();
 export const specAgentRepository = new FSSpecAgentRepository();
+export const devopsAgentRepository = new FSDevOpsAgentRepository();
 export const extensionRepository = new FSExtensionRepository();
 export const specifyCli = new ProcessSpecifyRunner();

--- a/src/adapters/secondary/agent/ProcessAgentRunner.ts
+++ b/src/adapters/secondary/agent/ProcessAgentRunner.ts
@@ -6,6 +6,7 @@ import {
   PersonaId,
   CostMetadata,
 } from "../../../domain/models/types";
+import { DevOpsAgent } from "../../../domain/models/devopsAgents";
 import type * as pty from "node-pty";
 import { loadPty } from "../pty/ptyLoader";
 import { meter } from "../../../domain/services/CostMeter";
@@ -33,6 +34,10 @@ export class ProcessAgentRunner implements AgentRunnerPort {
 
   private personaKey(featureName: string, id: PersonaId): string {
     return `${featureName}-impl-persona-${id}`;
+  }
+
+  private devopsKey(featureName: string | null, id: string): string {
+    return `${featureName || "global"}-devops-${id}`;
   }
 
   async writeStdin(
@@ -149,6 +154,31 @@ export class ProcessAgentRunner implements AgentRunnerPort {
     });
   }
 
+  async runDevOps(
+    workspacePath: string,
+    featureName: string | null,
+    agent: DevOpsAgent,
+    agentConfig: AgentConfig,
+    onData?: (text: string) => void,
+    onCost?: (cost: CostMetadata) => void,
+  ): Promise<number> {
+    // DevOps agents target a feature's artifacts when one is active, else run
+    // workspace-wide. The leading slash mirrors how phases/personas invoke commands.
+    const slash = agent.command.startsWith("/") ? agent.command : `/${agent.command}`;
+    const fullPrompt = featureName ? `${slash} specs/${featureName}` : slash;
+
+    return this.spawnAgent({
+      workspacePath,
+      procKey: this.devopsKey(featureName, agent.id),
+      doneTag: `devops:${agent.id}`,
+      agentConfig,
+      fullPrompt,
+      onData,
+      onCost,
+      devops: agent,
+    });
+  }
+
   // Shared spawn path for both phase and persona runs: spawns the agent CLI
   // under a PTY (so interactive CLIs detect a TTY), streams output, and resolves
   // with the exit code.
@@ -161,6 +191,7 @@ export class ProcessAgentRunner implements AgentRunnerPort {
     onData?: (text: string) => void;
     onCost?: (cost: CostMetadata) => void;
     persona?: PersonaConfig;
+    devops?: DevOpsAgent;
   }): Promise<number> {
     const { workspacePath, procKey, doneTag, agentConfig, fullPrompt, onData, onCost } =
       opts;
@@ -217,6 +248,15 @@ export class ProcessAgentRunner implements AgentRunnerPort {
                   : "",
               }
             : {}),
+          ...(opts.devops
+            ? {
+                SPECKIT_DEVOPS_ID: opts.devops.id || "",
+                SPECKIT_DEVOPS_LABEL: opts.devops.label || "",
+                SPECKIT_DEVOPS_CATEGORY: opts.devops.category || "",
+                SPECKIT_DEVOPS_MODEL: opts.devops.model || "",
+                SPECKIT_DEVOPS_SYSTEM_PROMPT: opts.devops.systemPrompt || "",
+              }
+            : {}),
         } as { [key: string]: string },
       });
 
@@ -244,7 +284,7 @@ export class ProcessAgentRunner implements AgentRunnerPort {
         try {
           const cost = meter({
             agentType: agentConfig.agentType,
-            model: opts.persona?.model ?? agentConfig.model,
+            model: opts.persona?.model ?? opts.devops?.model ?? agentConfig.model,
             promptText: fullPrompt,
             outputText: fullOutput,
             durationMs: Date.now() - startTime,

--- a/src/adapters/secondary/cli/ProcessSpecifyRunner.ts
+++ b/src/adapters/secondary/cli/ProcessSpecifyRunner.ts
@@ -1,13 +1,86 @@
 import { spawn } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { SpecifyCliPort, SpecifyRunResult } from '../../../domain/ports/out/SpecifyCliPort';
 
-const BIN = process.env.SPECIFY_BIN || 'specify';
+// Source zip used to install the CLI without requiring `git` on the host.
+const SPEC_KIT_ZIP_URL =
+  process.env.SPEC_KIT_ZIP_URL || 'https://github.com/github/spec-kit/archive/refs/heads/main.zip';
 const TIMEOUT_MS = 180_000;
+const INSTALL_TIMEOUT_MS = 300_000;
+const IS_WIN = process.platform === 'win32';
+const UV_EXE = IS_WIN ? 'uv.exe' : 'uv';
+const PY_EXE = IS_WIN ? 'python.exe' : 'python';
+const SPECIFY_EXE = IS_WIN ? 'specify.exe' : 'specify';
+
+// Bin dir name inside a virtualenv differs per platform.
+function venvBin(root: string): string {
+  return path.join(root, IS_WIN ? 'Scripts' : 'bin');
+}
+
+// Candidate venv roots, most specific first: an active venv ($VIRTUAL_ENV),
+// then common local venv layouts inside the workspace.
+function venvRootCandidates(workspacePath?: string): string[] {
+  const roots: string[] = [];
+  if (process.env.VIRTUAL_ENV) roots.push(process.env.VIRTUAL_ENV);
+  if (workspacePath) {
+    for (const name of ['.venv', 'venv', 'env']) roots.push(path.join(workspacePath, name));
+  }
+  return roots;
+}
+
+// The first candidate venv that actually contains a python interpreter, or null.
+function resolveVenvRoot(workspacePath?: string): string | null {
+  for (const root of venvRootCandidates(workspacePath)) {
+    if (fs.existsSync(path.join(venvBin(root), PY_EXE))) return root;
+  }
+  return null;
+}
+
+function venvBinDirs(workspacePath?: string): string[] {
+  return venvRootCandidates(workspacePath).map(venvBin);
+}
+
+// Resolve the `specify` binary, preferring the project's local venv over PATH.
+// An explicit SPECIFY_BIN env wins.
+function resolveSpecifyBin(workspacePath?: string): string {
+  if (process.env.SPECIFY_BIN) return process.env.SPECIFY_BIN;
+  const venv = resolveVenvRoot(workspacePath);
+  if (venv) {
+    const candidate = path.join(venvBin(venv), SPECIFY_EXE);
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return 'specify';
+}
+
+// Resolve the `uv` binary. An explicit UV_BIN env wins; otherwise prefer a
+// venv-local uv (workspace's .venv, or an active $VIRTUAL_ENV) before falling
+// back to `uv` on PATH.
+function resolveUvBin(workspacePath?: string): string {
+  if (process.env.UV_BIN) return process.env.UV_BIN;
+  for (const dir of venvBinDirs(workspacePath)) {
+    const candidate = path.join(dir, UV_EXE);
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return 'uv';
+}
+
+// Keep a venv-local `specify`/`python` and the uv tool bin dir (~/.local/bin,
+// the global fallback target) discoverable to spawned processes.
+function augmentedEnv(workspacePath?: string): NodeJS.ProcessEnv {
+  const extra = [...venvBinDirs(workspacePath), path.join(os.homedir(), '.local', 'bin')];
+  const sep = IS_WIN ? ';' : ':';
+  const current = process.env.PATH || '';
+  const parts = current.split(sep);
+  const missing = extra.filter(p => p && !parts.includes(p));
+  return missing.length ? { ...process.env, PATH: [...missing, ...parts].join(sep) } : process.env;
+}
 
 export class ProcessSpecifyRunner implements SpecifyCliPort {
-  async isAvailable(): Promise<boolean> {
+  async isAvailable(workspacePath?: string): Promise<boolean> {
     try {
-      const { code } = await this.exec(process.cwd(), ['--version'], 8000);
+      const { code } = await this.exec(resolveSpecifyBin(workspacePath), workspacePath ?? process.cwd(), ['--version'], 8000);
       return code === 0;
     } catch {
       return false;
@@ -15,10 +88,32 @@ export class ProcessSpecifyRunner implements SpecifyCliPort {
   }
 
   run(workspacePath: string, args: string[]): Promise<SpecifyRunResult> {
-    return this.exec(workspacePath, args, TIMEOUT_MS);
+    return this.exec(resolveSpecifyBin(workspacePath), workspacePath, args, TIMEOUT_MS);
   }
 
-  private exec(cwd: string, args: string[], timeoutMs: number): Promise<SpecifyRunResult> {
+  // Install into the project's local venv when one exists; otherwise fall back
+  // to a global `uv tool install`.
+  installCli(workspacePath: string): Promise<SpecifyRunResult> {
+    const uv = resolveUvBin(workspacePath);
+    const venv = resolveVenvRoot(workspacePath);
+    if (venv) {
+      const python = path.join(venvBin(venv), PY_EXE);
+      return this.exec(
+        uv,
+        workspacePath,
+        ['pip', 'install', '--python', python, '--reinstall', `specify-cli @ ${SPEC_KIT_ZIP_URL}`],
+        INSTALL_TIMEOUT_MS,
+      );
+    }
+    return this.exec(
+      uv,
+      workspacePath,
+      ['tool', 'install', 'specify-cli', '--from', SPEC_KIT_ZIP_URL, '--force'],
+      INSTALL_TIMEOUT_MS,
+    );
+  }
+
+  private exec(bin: string, cwd: string, args: string[], timeoutMs: number): Promise<SpecifyRunResult> {
     return new Promise((resolve) => {
       let output = '';
       let settled = false;
@@ -30,9 +125,9 @@ export class ProcessSpecifyRunner implements SpecifyCliPort {
 
       let child;
       try {
-        child = spawn(BIN, args, { cwd, env: process.env });
+        child = spawn(bin, args, { cwd, env: augmentedEnv(cwd) });
       } catch (err: any) {
-        resolve({ code: 127, output: `Failed to start ${BIN}: ${err.message}` });
+        resolve({ code: 127, output: `Failed to start ${bin}: ${err.message}` });
         return;
       }
 
@@ -55,7 +150,7 @@ export class ProcessSpecifyRunner implements SpecifyCliPort {
 
       child.on('error', (err) => {
         clearTimeout(timer);
-        output += `\n${BIN} error: ${err.message}`;
+        output += `\n${bin} error: ${err.message}`;
         finish(127);
       });
       child.on('close', (code) => {

--- a/src/adapters/secondary/fs/FSDevOpsAgentRepository.test.ts
+++ b/src/adapters/secondary/fs/FSDevOpsAgentRepository.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { FSDevOpsAgentRepository } from './FSDevOpsAgentRepository';
+import { DevOpsAgentsFile, DEFAULT_DEVOPS_AGENTS } from '../../../domain/models/devopsAgents';
+
+describe('FSDevOpsAgentRepository', () => {
+  let ws: string;
+  const repo = new FSDevOpsAgentRepository();
+
+  beforeEach(() => {
+    ws = fs.mkdtempSync(path.join(os.tmpdir(), 'devops-agents-'));
+  });
+  afterEach(() => {
+    fs.rmSync(ws, { recursive: true, force: true });
+  });
+
+  it('returns DEFAULT_DEVOPS_AGENTS when no roster exists', async () => {
+    const file = await repo.getAgents(ws);
+    expect(file.agents.map(a => a.id)).toEqual(DEFAULT_DEVOPS_AGENTS.agents.map(a => a.id));
+  });
+
+  it('round-trips the roster as YAML', async () => {
+    const file: DevOpsAgentsFile = {
+      agents: [
+        { id: 'devops-deploy', label: 'Deploy', command: 'speckit.devops.deploy', category: 'deploy', enabled: false, model: 'claude-sonnet-4-6', builtin: true },
+      ],
+    };
+    await repo.saveAgents(ws, file);
+    const raw = fs.readFileSync(path.join(ws, '.specify', 'devops-agents.yaml'), 'utf-8');
+    expect(raw).toMatch(/agents:/);
+    const loaded = await repo.getAgents(ws);
+    expect(loaded.agents[0].command).toBe('speckit.devops.deploy');
+    expect(loaded.agents[0].enabled).toBe(false);
+    expect(loaded.agents[0].model).toBe('claude-sonnet-4-6');
+  });
+
+  it('falls back to defaults on malformed YAML', async () => {
+    fs.mkdirSync(path.join(ws, '.specify'), { recursive: true });
+    fs.writeFileSync(path.join(ws, '.specify', 'devops-agents.yaml'), 'not: [valid', 'utf-8');
+    const file = await repo.getAgents(ws);
+    expect(file.agents.length).toBe(DEFAULT_DEVOPS_AGENTS.agents.length);
+  });
+});

--- a/src/adapters/secondary/fs/FSDevOpsAgentRepository.ts
+++ b/src/adapters/secondary/fs/FSDevOpsAgentRepository.ts
@@ -1,0 +1,29 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as yaml from 'js-yaml';
+import { DevOpsAgentRepositoryPort } from '../../../domain/ports/out/DevOpsAgentRepositoryPort';
+import { DevOpsAgentsFile, DEFAULT_DEVOPS_AGENTS } from '../../../domain/models/devopsAgents';
+
+export class FSDevOpsAgentRepository implements DevOpsAgentRepositoryPort {
+  private rosterPath(workspacePath: string): string {
+    return path.join(workspacePath, '.specify', 'devops-agents.yaml');
+  }
+
+  async getAgents(workspacePath: string): Promise<DevOpsAgentsFile> {
+    const fp = this.rosterPath(workspacePath);
+    if (!fs.existsSync(fp)) return JSON.parse(JSON.stringify(DEFAULT_DEVOPS_AGENTS));
+    try {
+      const parsed = yaml.load(fs.readFileSync(fp, 'utf-8')) as DevOpsAgentsFile;
+      if (!parsed || !Array.isArray(parsed.agents)) return JSON.parse(JSON.stringify(DEFAULT_DEVOPS_AGENTS));
+      return { agents: parsed.agents };
+    } catch {
+      return JSON.parse(JSON.stringify(DEFAULT_DEVOPS_AGENTS));
+    }
+  }
+
+  async saveAgents(workspacePath: string, file: DevOpsAgentsFile): Promise<void> {
+    const dir = path.join(workspacePath, '.specify');
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(this.rosterPath(workspacePath), yaml.dump(file, { lineWidth: 120 }), 'utf-8');
+  }
+}

--- a/src/adapters/secondary/fs/FSExecutionHistory.test.ts
+++ b/src/adapters/secondary/fs/FSExecutionHistory.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { FSExecutionHistory } from './FSExecutionHistory';
+
+describe('FSExecutionHistory', () => {
+  let ws: string;
+  const repo = new FSExecutionHistory();
+
+  beforeEach(() => {
+    ws = fs.mkdtempSync(path.join(os.tmpdir(), 'exec-history-'));
+  });
+  afterEach(() => {
+    fs.rmSync(ws, { recursive: true, force: true });
+  });
+
+  it('returns [] when no history exists', async () => {
+    expect(await repo.list(ws)).toEqual([]);
+  });
+
+  it('merges start + finish into a single record by id', async () => {
+    const rec = await repo.start(ws, { kind: 'devops', feature: 'auth', agentId: 'devops-deploy', label: 'Deploy', command: 'speckit.devops.deploy' });
+    let list = await repo.list(ws);
+    expect(list).toHaveLength(1);
+    expect(list[0].status).toBe('running');
+
+    await repo.finish(ws, rec.id, { status: 'passed', exitCode: 0, cost: { source: 'estimated', durationMs: 1234 } });
+    list = await repo.list(ws);
+    expect(list).toHaveLength(1);
+    expect(list[0].id).toBe(rec.id);
+    expect(list[0].status).toBe('passed');
+    expect(list[0].exitCode).toBe(0);
+    expect(list[0].completedAt).toBeGreaterThanOrEqual(list[0].startedAt);
+    expect(list[0].cost?.durationMs).toBe(1234);
+    // Original start fields survive the merge.
+    expect(list[0].label).toBe('Deploy');
+    expect(list[0].feature).toBe('auth');
+  });
+
+  it('captures and reads back the run log', async () => {
+    const rec = await repo.start(ws, { kind: 'phase', feature: 'auth', phase: 'specification', label: 'specification' });
+    repo.appendLog(ws, rec.id, 'line one\n');
+    repo.appendLog(ws, rec.id, 'line two\n');
+    expect(await repo.readLog(ws, rec.id)).toBe('line one\nline two\n');
+  });
+
+  it('filters by feature and sorts newest first', async () => {
+    // Ordering is deterministic via the monotonic seq tiebreaker even when the
+    // runs share a millisecond, so no sleeps are needed.
+    const a = await repo.start(ws, { kind: 'phase', feature: 'auth', label: 'a' });
+    const b = await repo.start(ws, { kind: 'phase', feature: 'billing', label: 'b' });
+    const c = await repo.start(ws, { kind: 'phase', feature: 'auth', label: 'c' });
+
+    const authOnly = await repo.list(ws, { feature: 'auth' });
+    expect(authOnly.map(r => r.id)).toEqual([c.id, a.id]);
+    expect((await repo.list(ws)).map(r => r.id)).toEqual([c.id, b.id, a.id]);
+  });
+});

--- a/src/adapters/secondary/fs/FSExecutionHistory.ts
+++ b/src/adapters/secondary/fs/FSExecutionHistory.ts
@@ -1,0 +1,121 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { ExecutionHistoryPort } from '../../../domain/ports/out/ExecutionHistoryPort';
+import {
+  ExecutionRecord,
+  ExecutionStartInput,
+  ExecutionFinishPatch,
+} from '../../../domain/models/executions';
+
+// Append-only execution history persisted under .specify/.runtime:
+//   executions.jsonl  — one JSON event per line (start snapshot + finish patch),
+//                        reduced by id (last write wins) on read.
+//   logs/<id>.log      — captured stdout/stderr for each run.
+
+// Monotonic counter so runs started within the same millisecond keep a stable,
+// deterministic order (startedAt alone has ms granularity).
+let SEQ = 0;
+
+export class FSExecutionHistory implements ExecutionHistoryPort {
+  private runtimeDir(workspacePath: string): string {
+    return path.join(workspacePath, '.specify', '.runtime');
+  }
+  private jsonlPath(workspacePath: string): string {
+    return path.join(this.runtimeDir(workspacePath), 'executions.jsonl');
+  }
+  private logsDir(workspacePath: string): string {
+    return path.join(this.runtimeDir(workspacePath), 'logs');
+  }
+  private logFile(workspacePath: string, id: string): string {
+    return path.join(this.logsDir(workspacePath), `${this.safeId(id)}.log`);
+  }
+  // Ids are generated here, but sanitise defensively before using them in paths.
+  private safeId(id: string): string {
+    return id.replace(/[^a-zA-Z0-9_-]/g, '');
+  }
+
+  private appendEvent(workspacePath: string, event: Record<string, unknown>): void {
+    const dir = this.runtimeDir(workspacePath);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    fs.appendFileSync(this.jsonlPath(workspacePath), JSON.stringify(event) + '\n', 'utf-8');
+  }
+
+  async start(workspacePath: string, input: ExecutionStartInput): Promise<ExecutionRecord> {
+    const id = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const record: ExecutionRecord = {
+      id,
+      kind: input.kind,
+      feature: input.feature,
+      ...(input.phase ? { phase: input.phase } : {}),
+      ...(input.agentId ? { agentId: input.agentId } : {}),
+      label: input.label,
+      ...(input.command ? { command: input.command } : {}),
+      status: 'running',
+      startedAt: Date.now(),
+      seq: SEQ++,
+      logPath: path.join('.specify', '.runtime', 'logs', `${id}.log`),
+    };
+    this.appendEvent(workspacePath, record as unknown as Record<string, unknown>);
+    // Touch the log file so the path exists even for a silent run.
+    try {
+      if (!fs.existsSync(this.logsDir(workspacePath))) fs.mkdirSync(this.logsDir(workspacePath), { recursive: true });
+      fs.writeFileSync(this.logFile(workspacePath, id), '', { flag: 'a' });
+    } catch {
+      // best-effort
+    }
+    return record;
+  }
+
+  appendLog(workspacePath: string, id: string, text: string): void {
+    try {
+      const dir = this.logsDir(workspacePath);
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+      fs.appendFileSync(this.logFile(workspacePath, id), text, 'utf-8');
+    } catch {
+      // logging is best-effort; never block a run on it
+    }
+  }
+
+  async finish(workspacePath: string, id: string, patch: ExecutionFinishPatch): Promise<void> {
+    this.appendEvent(workspacePath, {
+      id,
+      status: patch.status,
+      completedAt: Date.now(),
+      ...(typeof patch.exitCode === 'number' ? { exitCode: patch.exitCode } : {}),
+      ...(patch.cost ? { cost: patch.cost } : {}),
+    });
+  }
+
+  async list(workspacePath: string, filter?: { feature?: string }): Promise<ExecutionRecord[]> {
+    const fp = this.jsonlPath(workspacePath);
+    if (!fs.existsSync(fp)) return [];
+    const merged = new Map<string, ExecutionRecord>();
+    const lines = fs.readFileSync(fp, 'utf-8').split('\n');
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let event: any;
+      try {
+        event = JSON.parse(trimmed);
+      } catch {
+        continue;
+      }
+      if (!event || typeof event.id !== 'string') continue;
+      const prev = merged.get(event.id);
+      merged.set(event.id, { ...(prev || {}), ...event } as ExecutionRecord);
+    }
+    let records = [...merged.values()].filter(r => typeof r.startedAt === 'number');
+    if (filter?.feature) records = records.filter(r => r.feature === filter.feature);
+    return records.sort((a, b) => b.startedAt - a.startedAt || (b.seq ?? 0) - (a.seq ?? 0));
+  }
+
+  async readLog(workspacePath: string, id: string): Promise<string> {
+    const fp = this.logFile(workspacePath, id);
+    if (!fs.existsSync(fp)) return '';
+    try {
+      return fs.readFileSync(fp, 'utf-8');
+    } catch {
+      return '';
+    }
+  }
+}

--- a/src/adapters/secondary/fs/FSExtensionRepository.test.ts
+++ b/src/adapters/secondary/fs/FSExtensionRepository.test.ts
@@ -38,14 +38,14 @@ describe('FSExtensionRepository', () => {
         '  description: "Specification agents."',
         'provides:',
         '  commands:',
-        '    - name: "speckit.spec.po"',
+        '    - name: "speckit.spec-agents.po"',
         '      file: "commands/po.md"',
-        '    - name: "speckit.spec.architecture"',
+        '    - name: "speckit.spec-agents.architecture"',
         '      file: "commands/architecture.md"',
         'hooks:',
         '  after_specify:',
         '    - id: spec-po',
-        '      command: "speckit.spec.po"',
+        '      command: "speckit.spec-agents.po"',
       ].join('\n'),
       'utf-8'
     );

--- a/src/adapters/secondary/fs/FSSpecAgentRepository.test.ts
+++ b/src/adapters/secondary/fs/FSSpecAgentRepository.test.ts
@@ -24,12 +24,12 @@ describe('FSSpecAgentRepository', () => {
 
   it('round-trips the roster as YAML', async () => {
     const file: SpecAgentsFile = {
-      agents: [{ id: 'spec-po', label: 'PO', command: 'speckit.spec.po', enabled: true, optional: true, priority: 10, builtin: true }],
+      agents: [{ id: 'spec-po', label: 'PO', command: 'speckit.spec-agents.po', enabled: true, optional: true, priority: 10, builtin: true }],
     };
     await repo.saveAgents(ws, file);
     const raw = fs.readFileSync(path.join(ws, '.specify', 'spec-agents.yaml'), 'utf-8');
     expect(raw).toMatch(/agents:/);
-    expect((await repo.getAgents(ws)).agents[0].command).toBe('speckit.spec.po');
+    expect((await repo.getAgents(ws)).agents[0].command).toBe('speckit.spec-agents.po');
   });
 
   it('applies hooks into extensions.yml preserving other events/entries', async () => {
@@ -48,8 +48,8 @@ describe('FSSpecAgentRepository', () => {
 
     const file: SpecAgentsFile = {
       agents: [
-        { id: 'spec-po', label: 'PO', command: 'speckit.spec.po', enabled: true, optional: true, priority: 10, builtin: true },
-        { id: 'spec-arch', label: 'Arch', command: 'speckit.spec.architecture', enabled: false, optional: true, priority: 20, builtin: true },
+        { id: 'spec-po', label: 'PO', command: 'speckit.spec-agents.po', enabled: true, optional: true, priority: 10, builtin: true },
+        { id: 'spec-arch', label: 'Arch', command: 'speckit.spec-agents.architecture', enabled: false, optional: true, priority: 20, builtin: true },
       ],
     };
 
@@ -67,7 +67,7 @@ describe('FSSpecAgentRepository', () => {
 
   it('writes a command file for a custom agent with a prompt', async () => {
     const file: SpecAgentsFile = {
-      agents: [{ id: 'qa-spec', label: 'Spec QA', command: 'speckit.spec.qa-spec', systemPrompt: 'Check testability.', enabled: true, optional: true, priority: 40 }],
+      agents: [{ id: 'qa-spec', label: 'Spec QA', command: 'speckit.spec-agents.qa-spec', systemPrompt: 'Check testability.', enabled: true, optional: true, priority: 40 }],
     };
     const res = await repo.applyToSpecKit(ws, file);
     const cmd = path.join(ws, '.specify', 'spec-agents', 'commands', 'qa-spec.md');

--- a/src/app/api/devops-agents/route.ts
+++ b/src/app/api/devops-agents/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { devopsAgentRepository } from '../../../adapters/di';
+import { getWorkspacePath } from '../../../adapters/primary/api/utils';
+import { DevOpsAgentsFile } from '../../../domain/models/devopsAgents';
+
+export async function GET() {
+  try {
+    const workspacePath = getWorkspacePath();
+    const file = await devopsAgentRepository.getAgents(workspacePath);
+    return NextResponse.json(file);
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = (await req.json()) as DevOpsAgentsFile;
+    if (!body || !Array.isArray(body.agents)) {
+      return NextResponse.json({ error: 'Body must be a DevOpsAgentsFile with an agents array' }, { status: 400 });
+    }
+    const workspacePath = getWorkspacePath();
+    await devopsAgentRepository.saveAgents(workspacePath, body);
+    return NextResponse.json({ success: true, agents: body.agents });
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}

--- a/src/app/api/devops/run/route.ts
+++ b/src/app/api/devops/run/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from 'next/server';
+import { workflowService, devopsAgentRepository, extensionRepository } from '../../../../adapters/di';
+import { getWorkspacePath } from '../../../../adapters/primary/api/utils';
+import { AgentConfig } from '../../../../domain/models/types';
+import { DEVOPS_AGENTS_EXTENSION_ID } from '../../../../domain/models/devopsAgents';
+
+export async function POST(req: Request) {
+  try {
+    const { agentId, featureName, agentConfig } = await req.json();
+    if (!agentId) return NextResponse.json({ error: 'Missing agentId' }, { status: 400 });
+
+    const workspacePath = getWorkspacePath();
+
+    const roster = await devopsAgentRepository.getAgents(workspacePath);
+    const agent = roster.agents.find(a => a.id === agentId);
+    if (!agent) return NextResponse.json({ error: `Unknown DevOps agent: ${agentId}` }, { status: 400 });
+    if (!agent.enabled) return NextResponse.json({ error: `DevOps agent is disabled: ${agentId}` }, { status: 400 });
+
+    // The slash command only resolves if the bundled devops extension is installed.
+    const installed = await extensionRepository.listInstalled(workspacePath);
+    const devopsInstalled = installed.some(e => e.id === DEVOPS_AGENTS_EXTENSION_ID && e.enabled);
+    if (!devopsInstalled) {
+      return NextResponse.json({
+        error: 'The DevOps extension is not installed. Install "DevOps Agents" from the Extensions panel first.',
+      }, { status: 409 });
+    }
+
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      async start(controller) {
+        const sendEvent = (event: string, data: any) => {
+          controller.enqueue(encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`));
+        };
+        try {
+          const { exitCode } = await workflowService.runDevOps(
+            workspacePath,
+            agent,
+            featureName ?? null,
+            agentConfig as AgentConfig,
+            (t: string) => sendEvent('log', { text: t })
+          );
+          sendEvent('done', { exitCode });
+          controller.close();
+        } catch (err: any) {
+          sendEvent('error', { message: err.message });
+          controller.close();
+        }
+      },
+    });
+
+    return new Response(stream, {
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        'Connection': 'keep-alive',
+      },
+    });
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}

--- a/src/app/api/executions/log/route.ts
+++ b/src/app/api/executions/log/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import { executionHistory } from '../../../../adapters/di';
+import { getWorkspacePath } from '../../../../adapters/primary/api/utils';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: Request) {
+  try {
+    const id = new URL(req.url).searchParams.get('id');
+    if (!id) return NextResponse.json({ error: 'Missing id' }, { status: 400 });
+    const workspacePath = getWorkspacePath();
+    const log = await executionHistory.readLog(workspacePath, id);
+    return NextResponse.json({ id, log });
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}

--- a/src/app/api/executions/route.ts
+++ b/src/app/api/executions/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import { executionHistory } from '../../../adapters/di';
+import { getWorkspacePath } from '../../../adapters/primary/api/utils';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: Request) {
+  try {
+    const workspacePath = getWorkspacePath();
+    const feature = new URL(req.url).searchParams.get('feature') || undefined;
+    const executions = await executionHistory.list(workspacePath, feature ? { feature } : undefined);
+    return NextResponse.json({ executions });
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}

--- a/src/app/api/extensions/route.ts
+++ b/src/app/api/extensions/route.ts
@@ -8,7 +8,7 @@ export async function GET() {
   try {
     const workspacePath = getWorkspacePath();
     const [available, installed] = await Promise.all([
-      specifyCli.isAvailable(),
+      specifyCli.isAvailable(workspacePath),
       extensionRepository.listInstalled(workspacePath),
     ]);
     return NextResponse.json({ available, installed, bundled: BUNDLED_EXTENSIONS });
@@ -22,6 +22,14 @@ export async function POST(req: Request) {
     const body = await req.json();
     const { action } = body || {};
     if (!action) return NextResponse.json({ error: 'Missing action' }, { status: 400 });
+
+    // Install the `specify` CLI itself (separate from `specify extension ...`).
+    if (action === 'install-cli') {
+      const wsPath = getWorkspacePath();
+      const { code, output } = await specifyCli.installCli(wsPath);
+      const available = await specifyCli.isAvailable(wsPath);
+      return NextResponse.json({ success: code === 0, code, output, available });
+    }
 
     // Resolve a bundled extension's local directory into a --dev install.
     let input: SpecifyActionInput;

--- a/src/app/api/state/watch/route.ts
+++ b/src/app/api/state/watch/route.ts
@@ -43,11 +43,16 @@ export async function GET() {
       // Watch all change events (add, change, unlink)
       watcher.on('all', (event, filePath) => {
         if (filePath.includes('.git')) return;
-        // The internal runtime dir is otherwise noisy, but workflow-state.json
-        // holds the phase statuses (e.g. 'running'), so let that one through —
-        // it's what tells the Kanban a phase is executing. getWorkflowState is
-        // read-only, so re-emitting on it cannot create a write/watch loop.
-        if (filePath.includes('.runtime') && !filePath.includes('workflow-state.json')) return;
+        // The internal runtime dir is otherwise noisy, but two files matter to the
+        // UI: workflow-state.json (phase statuses, e.g. 'running' — what tells the
+        // Kanban a phase is executing) and executions.jsonl (the executions feed).
+        // Per-run logs/*.log are intentionally still ignored (too chatty). These
+        // reads are read-only, so re-emitting cannot create a write/watch loop.
+        if (
+          filePath.includes('.runtime') &&
+          !filePath.includes('workflow-state.json') &&
+          !filePath.includes('executions.jsonl')
+        ) return;
         sendUpdate(filePath);
       });
     },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -284,9 +284,13 @@ export default function Dashboard() {
       body: JSON.stringify(a),
     });
     const data = await res.json();
-    if (Array.isArray(data.installed)) {
-      setExtState(prev => ({ ...prev, installed: data.installed }));
-    }
+    setExtState(prev => ({
+      ...prev,
+      ...(Array.isArray(data.installed) ? { installed: data.installed } : {}),
+      ...(typeof data.available === 'boolean' ? { available: data.available } : {}),
+    }));
+    // The CLI just became available — refresh installed extensions too.
+    if (a.action === 'install-cli' && data.available) fetchExtensions();
     return data;
   };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -28,9 +28,12 @@ import AgentsPanel from '@/components/AgentsPanel';
 import McpPanel from '@/components/McpPanel';
 import ExtensionsPanel, { type ExtensionAction } from '@/components/ExtensionsPanel';
 import AboutModal, { APP_VERSION } from '@/components/AboutModal';
+import ExecutionsView from '@/components/ExecutionsView';
 import { AgentsFile, DEFAULT_AGENTS, toAgentConfig, activeAgent } from '@/domain/models/agents';
 import { McpFile, DEFAULT_MCP } from '@/domain/models/mcp';
 import { SpecAgentsFile, DEFAULT_SPEC_AGENTS } from '@/domain/models/specAgents';
+import { DevOpsAgentsFile, DEFAULT_DEVOPS_AGENTS } from '@/domain/models/devopsAgents';
+import { ExecutionRecord } from '@/domain/models/executions';
 import { InstalledExtension, BundledExtension } from '@/domain/models/extensions';
 import {
   Sun,
@@ -51,7 +54,8 @@ import {
   ShieldCheck,
   Bot,
   Plug,
-  Package
+  Package,
+  Activity
 } from 'lucide-react';
 
 const PHASE_LABELS: Record<WorkflowPhase, string> = {
@@ -71,7 +75,7 @@ export default function Dashboard() {
   const agentConsoleRef = React.useRef<AgentConsoleHandle | null>(null);
   const [selectedFile, setSelectedFile] = useState<{ path: string; content: string } | null>(null);
   
-  const [viewMode, setViewMode] = useState<'kanban' | 'dag'>('kanban');
+  const [viewMode, setViewMode] = useState<'kanban' | 'dag' | 'executions'>('kanban');
   const [section, setSection] = useState<'workflow' | 'agents' | 'mcp' | 'extensions'>('workflow');
   const [theme, setTheme] = useState<'light' | 'dark'>('light');
   const [agentConfig, setAgentConfig] = useState<AgentConfig>({
@@ -82,6 +86,9 @@ export default function Dashboard() {
   const [agentsFile, setAgentsFile] = useState<AgentsFile>(DEFAULT_AGENTS);
   const [mcpFile, setMcpFile] = useState<McpFile>(DEFAULT_MCP);
   const [specAgentsFile, setSpecAgentsFile] = useState<SpecAgentsFile>(DEFAULT_SPEC_AGENTS);
+  const [devopsAgentsFile, setDevopsAgentsFile] = useState<DevOpsAgentsFile>(DEFAULT_DEVOPS_AGENTS);
+  const [executions, setExecutions] = useState<ExecutionRecord[]>([]);
+  const [runningDevOps, setRunningDevOps] = useState<string | null>(null);
   const [extState, setExtState] = useState<{ available: boolean; installed: InstalledExtension[]; bundled: BundledExtension[] }>({ available: false, installed: [], bundled: [] });
   const [prompt, setPrompt] = useState<string>('');
   const [personaConfigs, setPersonaConfigs] = useState<PersonaConfig[]>(DEFAULT_PERSONAS);
@@ -127,6 +134,8 @@ export default function Dashboard() {
     fetchAgents();
     fetchMcp();
     fetchSpecAgents();
+    fetchDevOpsAgents();
+    fetchExecutions();
     fetchExtensions();
 
     // Default to light mode
@@ -141,6 +150,11 @@ export default function Dashboard() {
       const changedFile = payload.changedFile || null;
 
       setState(newState);
+
+      // The executions feed is watched too; refresh it whenever the workspace changes.
+      if (!changedFile || changedFile.includes('executions.jsonl') || changedFile.includes('workflow-state.json')) {
+        fetchExecutions();
+      }
 
       if (selectedFileRef.current && changedFile) {
         const currentPath = selectedFileRef.current.path.replace(/\\/g, '/');
@@ -266,6 +280,90 @@ export default function Dashboard() {
       body: JSON.stringify(specAgentsFile),
     });
     return res.json();
+  };
+
+  const fetchDevOpsAgents = async () => {
+    try {
+      const res = await fetch('/api/devops-agents');
+      if (res.ok) setDevopsAgentsFile(await res.json());
+    } catch (err) {
+      console.error('Failed to fetch devops agents:', err);
+    }
+  };
+
+  const handleSaveDevOpsAgents = async (file: DevOpsAgentsFile) => {
+    setDevopsAgentsFile(file);
+    try {
+      await fetch('/api/devops-agents', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(file),
+      });
+    } catch (err) {
+      console.error('Failed to save devops agents:', err);
+    }
+  };
+
+  const fetchExecutions = async () => {
+    try {
+      const res = await fetch('/api/executions');
+      if (res.ok) setExecutions((await res.json()).executions || []);
+    } catch (err) {
+      console.error('Failed to fetch executions:', err);
+    }
+  };
+
+  const handleRunDevOps = async (agentId: string) => {
+    const agent = devopsAgentsFile.agents.find(a => a.id === agentId);
+    agentConsoleRef.current?.clear();
+    agentConsoleRef.current?.write(`\x1b[36m=== DevOps: ${agent?.label || agentId} ===\x1b[0m\r\n`);
+    setRunningDevOps(agentId);
+    setActiveTab('console');
+    try {
+      const response = await fetch('/api/devops/run', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ agentId, featureName: state?.activeFeatureName || null, agentConfig }),
+      });
+      // Non-SSE error responses (e.g. extension not installed) come back as JSON.
+      if (!response.ok || !response.body) {
+        const err = await response.json().catch(() => ({ error: 'Run failed' }));
+        agentConsoleRef.current?.write(`\r\n\x1b[31mError: ${err.error}\x1b[0m\r\n`);
+        return;
+      }
+      await consumeDevOpsStream(response);
+    } catch (err: any) {
+      agentConsoleRef.current?.write(`\r\n\x1b[31mExecution failed: ${err.message}\x1b[0m\r\n`);
+    } finally {
+      setRunningDevOps(null);
+      fetchExecutions();
+    }
+  };
+
+  const consumeDevOpsStream = async (response: Response) => {
+    const reader = response.body!.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value);
+      const lines = buffer.split('\n\n');
+      buffer = lines.pop() || '';
+      for (const line of lines) {
+        const dataLine = line.split('\n').find(l => l.startsWith('data: '));
+        if (!dataLine) continue;
+        const data = JSON.parse(dataLine.substring(6));
+        if (line.startsWith('event: log')) {
+          agentConsoleRef.current?.write(data.text);
+        } else if (line.startsWith('event: done')) {
+          agentConsoleRef.current?.write(`\r\n\x1b[32mDevOps run finished (exit ${data.exitCode}).\x1b[0m\r\n`);
+        } else if (line.startsWith('event: error')) {
+          agentConsoleRef.current?.write(`\r\n\x1b[31mError: ${data.message}\x1b[0m\r\n`);
+        }
+      }
+    }
+    fetchExecutions();
   };
 
   const fetchExtensions = async () => {
@@ -830,6 +928,13 @@ export default function Dashboard() {
                   <GitFork size={13} />
                   <span>DAG Map</span>
                 </button>
+                <button
+                  onClick={() => setViewMode('executions')}
+                  className={`p-1.5 rounded-md transition text-xs flex items-center gap-1.5 ${viewMode === 'executions' ? 'bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-50 shadow-sm' : 'text-zinc-500 hover:text-zinc-800 dark:hover:text-zinc-200'}`}
+                >
+                  <Activity size={13} />
+                  <span>Executions</span>
+                </button>
               </div>
 
               {/* Review Portal / Audit Trigger */}
@@ -876,9 +981,11 @@ export default function Dashboard() {
             mcpServers={mcpFile.servers}
             personaConfigs={personaConfigs}
             specAgentsFile={specAgentsFile}
+            devopsAgentsFile={devopsAgentsFile}
             onSaveAgents={handleSaveAgents}
             onSavePersonas={handleSavePersonasList}
             onSaveSpecAgents={handleSaveSpecAgents}
+            onSaveDevOpsAgents={handleSaveDevOpsAgents}
             onEditPersona={setEditingPersona}
             onApply={handleApplyMcp}
             onApplySpecAgents={handleApplySpecAgents}
@@ -1063,11 +1170,20 @@ export default function Dashboard() {
                       onOpenReview={(name, phaseState) => setAuditingFeature({ name, phaseState })}
                       onStopPhase={handleStopPhase}
                     />
-                  ) : (
+                  ) : viewMode === 'dag' ? (
                     <DagMap
                       state={state}
                       onSelectFeature={handleSelectFeature}
                       onSelectPhaseFile={handleLoadFile}
+                    />
+                  ) : (
+                    <ExecutionsView
+                      state={state}
+                      executions={executions}
+                      devopsAgents={devopsAgentsFile.agents}
+                      runningDevOps={runningDevOps}
+                      onRunDevOps={handleRunDevOps}
+                      theme={theme}
                     />
                   )
                 ) : (

--- a/src/components/AboutModal.tsx
+++ b/src/components/AboutModal.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { X, Globe, Github } from 'lucide-react';
 
 // Keep in sync with package.json "version".
-export const APP_VERSION = '0.3.0';
+export const APP_VERSION = '0.4.0';
 export const CREATOR = {
   name: 'Rafael Sales',
   website: 'https://rfsales.dev',

--- a/src/components/AgentsPanel.tsx
+++ b/src/components/AgentsPanel.tsx
@@ -1,24 +1,28 @@
 'use client';
 
 import React, { useState } from 'react';
-import { Bot, Plus, Pencil, Trash2, CheckCircle2, Circle, UploadCloud, Shield, Users, ArrowUp, ArrowDown } from 'lucide-react';
+import { Bot, Plus, Pencil, Trash2, CheckCircle2, Circle, UploadCloud, Shield, Users, ArrowUp, ArrowDown, Rocket } from 'lucide-react';
 import { AgentsFile, AgentProfile } from '../domain/models/agents';
 import { McpServer } from '../domain/models/mcp';
 import { PersonaConfig } from '../domain/models/types';
 import { SpecAgentsFile, SpecAgent } from '../domain/models/specAgents';
+import { DevOpsAgentsFile, DevOpsAgent } from '../domain/models/devopsAgents';
 import type { McpApplyResult } from '../domain/ports/out/McpConfigPort';
 import type { SpecAgentApplyResult } from '../domain/ports/out/SpecAgentRepositoryPort';
 import { AgentEditorModal } from './AgentEditorModal';
 import { SpecAgentEditorModal } from './SpecAgentEditorModal';
+import { DevOpsAgentEditorModal } from './DevOpsAgentEditorModal';
 
 type AgentsPanelProps = {
   agentsFile: AgentsFile;
   mcpServers: McpServer[];
   personaConfigs: PersonaConfig[];
   specAgentsFile: SpecAgentsFile;
+  devopsAgentsFile: DevOpsAgentsFile;
   onSaveAgents: (file: AgentsFile) => void;
   onSavePersonas: (next: PersonaConfig[]) => void;
   onSaveSpecAgents: (file: SpecAgentsFile) => void;
+  onSaveDevOpsAgents: (file: DevOpsAgentsFile) => void;
   onEditPersona: (p: PersonaConfig) => void;
   onApply: (agentId: string) => Promise<McpApplyResult & { error?: string }>;
   onApplySpecAgents: () => Promise<SpecAgentApplyResult & { error?: string }>;
@@ -29,9 +33,11 @@ export const AgentsPanel: React.FC<AgentsPanelProps> = ({
   mcpServers,
   personaConfigs,
   specAgentsFile,
+  devopsAgentsFile,
   onSaveAgents,
   onSavePersonas,
   onSaveSpecAgents,
+  onSaveDevOpsAgents,
   onEditPersona,
   onApply,
   onApplySpecAgents,
@@ -84,6 +90,16 @@ export const AgentsPanel: React.FC<AgentsPanelProps> = ({
       setSpecApplying(false);
     }
   };
+
+  // DevOps agents state
+  const [editingDevops, setEditingDevops] = useState<DevOpsAgent | null>(null);
+  const devopsAgents = devopsAgentsFile.agents;
+  const upsertDevops = (a: DevOpsAgent) => {
+    onSaveDevOpsAgents({ agents: devopsAgents.map(x => (x.id === a.id ? a : x)) });
+    setEditingDevops(null);
+  };
+  const toggleDevops = (id: string, patch: Partial<DevOpsAgent>) =>
+    onSaveDevOpsAgents({ agents: devopsAgents.map(a => (a.id === id ? { ...a, ...patch } : a)) });
 
   const agents = agentsFile.agents;
 
@@ -317,6 +333,36 @@ export const AgentsPanel: React.FC<AgentsPanelProps> = ({
         </div>
       </div>
 
+      {/* DevOps agents */}
+      <div className="mt-10">
+        <h2 className="text-lg font-bold text-zinc-900 dark:text-white flex items-center gap-2">
+          <Rocket size={18} /> DevOps Agents
+        </h2>
+        <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-0.5 mb-3">
+          Operational agents run on demand from the <span className="font-semibold">Executions</span> view (Deploy, Monitor,
+          Troubleshoot). Requires the <span className="font-mono">DevOps Agents</span> extension installed.
+        </p>
+
+        <div className="space-y-2">
+          {devopsAgents.map(a => (
+            <div key={a.id} className="flex items-center gap-3 p-3 bg-white dark:bg-zinc-950 border border-zinc-200 dark:border-zinc-800 rounded-lg">
+              <input type="checkbox" checked={a.enabled} onChange={e => toggleDevops(a.id, { enabled: e.target.checked })} className="w-4 h-4 rounded border-zinc-300 dark:border-zinc-700 text-blue-500 focus:ring-0" />
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-bold text-zinc-900 dark:text-white truncate">{a.label}</span>
+                  <span className="text-[8px] font-bold px-1 py-0.5 rounded bg-zinc-100 dark:bg-zinc-900 text-zinc-500 uppercase">{a.category}</span>
+                  <span className="text-[9px] font-mono text-zinc-500">{a.command}</span>
+                </div>
+                {a.description && <p className="text-[11px] text-zinc-500 dark:text-zinc-400 truncate">{a.description}</p>}
+              </div>
+              <span className="text-[9px] font-mono text-zinc-500 shrink-0">{a.model || 'default model'}</span>
+              <button onClick={() => setEditingDevops(a)} className="p-1.5 rounded text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-200 hover:bg-zinc-100 dark:hover:bg-zinc-900 transition" title="Edit"><Pencil size={13} /></button>
+            </div>
+          ))}
+          {devopsAgents.length === 0 && <p className="text-xs text-zinc-500 italic">No DevOps agents.</p>}
+        </div>
+      </div>
+
       <AgentEditorModal
         isOpen={creating || editing !== null}
         onClose={() => { setEditing(null); setCreating(false); }}
@@ -330,6 +376,13 @@ export const AgentsPanel: React.FC<AgentsPanelProps> = ({
         onClose={() => { setEditingSpec(null); setCreatingSpec(false); }}
         agent={editingSpec}
         onSave={upsertSpec}
+      />
+
+      <DevOpsAgentEditorModal
+        isOpen={editingDevops !== null}
+        onClose={() => setEditingDevops(null)}
+        agent={editingDevops}
+        onSave={upsertDevops}
       />
     </div>
   );

--- a/src/components/DevOpsAgentEditorModal.tsx
+++ b/src/components/DevOpsAgentEditorModal.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { X, Save, Rocket } from 'lucide-react';
+import { DevOpsAgent, DevOpsCategory } from '../domain/models/devopsAgents';
+import { MODEL_OPTIONS } from '../domain/models/modelOptions';
+
+type DevOpsAgentEditorModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  agent: DevOpsAgent | null;
+  onSave: (agent: DevOpsAgent) => void;
+};
+
+const input =
+  'w-full px-3 py-2 text-xs bg-zinc-50 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded outline-none text-zinc-900 dark:text-white focus:border-zinc-400 dark:focus:border-zinc-700';
+const labelCls = 'block text-[10px] font-bold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-1.5';
+
+const CATEGORIES: DevOpsCategory[] = ['deploy', 'monitor', 'troubleshoot'];
+
+export const DevOpsAgentEditorModal: React.FC<DevOpsAgentEditorModalProps> = ({ isOpen, onClose, agent, onSave }) => {
+  const [label, setLabel] = useState('');
+  const [description, setDescription] = useState('');
+  const [model, setModel] = useState('');
+  const [systemPrompt, setSystemPrompt] = useState('');
+  const [category, setCategory] = useState<DevOpsCategory>('deploy');
+
+  const builtin = !!agent?.builtin;
+
+  useEffect(() => {
+    setLabel(agent?.label || '');
+    setDescription(agent?.description || '');
+    setModel(agent?.model || '');
+    setSystemPrompt(agent?.systemPrompt || '');
+    setCategory(agent?.category || 'deploy');
+  }, [agent, isOpen]);
+
+  if (!isOpen || !agent) return null;
+
+  const handleSave = () => {
+    onSave({
+      ...agent,
+      label: label.trim() || agent.label,
+      category,
+      description: description.trim() || undefined,
+      model: model.trim() || undefined,
+      systemPrompt: builtin ? agent.systemPrompt : systemPrompt.trim() || undefined,
+    });
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 dark:bg-black/80 backdrop-blur-sm z-50 flex items-center justify-center p-4">
+      <div className="bg-white dark:bg-zinc-950 border border-zinc-200 dark:border-zinc-800 w-full max-w-2xl max-h-[88vh] rounded-xl flex flex-col overflow-hidden shadow-2xl animate-in fade-in zoom-in duration-200">
+        <header className="px-6 py-4 border-b border-zinc-200 dark:border-zinc-800 flex justify-between items-center bg-zinc-50 dark:bg-zinc-900/50">
+          <div className="flex items-center gap-3">
+            <div className="p-2 bg-blue-500/10 text-blue-600 dark:text-blue-400 rounded-lg">
+              <Rocket size={18} />
+            </div>
+            <div>
+              <h2 className="text-base font-bold text-zinc-900 dark:text-white tracking-tight">Edit DevOps Agent</h2>
+              <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-0.5">
+                Operational agent run on demand from the Executions view.
+              </p>
+            </div>
+          </div>
+          <button onClick={onClose} className="p-1.5 hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-lg text-zinc-500 dark:text-zinc-400 transition">
+            <X size={18} />
+          </button>
+        </header>
+
+        <div className="flex-1 overflow-y-auto p-6 space-y-5">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label className={labelCls}>Agent Name</label>
+              <input className={input} value={label} onChange={e => setLabel(e.target.value)} placeholder="e.g. Deploy" />
+            </div>
+            <div>
+              <label className={labelCls}>Category</label>
+              <select className={input} value={category} onChange={e => setCategory(e.target.value as DevOpsCategory)} disabled={builtin}>
+                {CATEGORIES.map(c => (<option key={c} value={c}>{c}</option>))}
+              </select>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label className={labelCls}>Slash Command</label>
+              <input className={`${input} font-mono disabled:opacity-60`} value={agent.command} disabled />
+            </div>
+            <div>
+              <label className={labelCls}>Model (optional)</label>
+              <input className={input} value={model} onChange={e => setModel(e.target.value)} placeholder="e.g. claude-sonnet-4-6" list="devops-model-options" />
+              <datalist id="devops-model-options">
+                {MODEL_OPTIONS.map(m => (<option key={m.value} value={m.value}>{m.label}</option>))}
+              </datalist>
+            </div>
+          </div>
+
+          <div>
+            <label className={labelCls}>Description</label>
+            <textarea rows={2} className={`${input} resize-none`} value={description} onChange={e => setDescription(e.target.value)} placeholder="What this agent does..." />
+          </div>
+
+          <div>
+            <label className={labelCls}>System Prompt {builtin && '(provided by the bundled extension)'}</label>
+            {builtin ? (
+              <p className="text-[11px] text-zinc-500 italic">
+                Built-in agents are backed by the <span className="font-mono">spec-kit-devops</span> extension command file.
+                Edit the extension to change its prompt; the model override above is passed at run time.
+              </p>
+            ) : (
+              <textarea rows={6} className={`${input} font-mono`} value={systemPrompt} onChange={e => setSystemPrompt(e.target.value)} placeholder="You are a ... " />
+            )}
+          </div>
+        </div>
+
+        <footer className="px-6 py-4 border-t border-zinc-200 dark:border-zinc-800 flex justify-end gap-3 bg-zinc-50 dark:bg-zinc-900/30">
+          <button onClick={onClose} className="px-4 py-2 bg-zinc-100 dark:bg-zinc-900 hover:bg-zinc-200 dark:hover:bg-zinc-800 border border-zinc-200 dark:border-zinc-800 text-zinc-700 dark:text-zinc-300 font-semibold text-xs rounded-lg transition">
+            Cancel
+          </button>
+          <button onClick={handleSave} className="px-4 py-2 bg-blue-500 hover:bg-blue-600 text-white font-semibold text-xs rounded-lg transition flex items-center gap-1.5">
+            <Save size={14} /> <span>Save Agent</span>
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+};
+
+export default DevOpsAgentEditorModal;

--- a/src/components/ExecutionGraph.tsx
+++ b/src/components/ExecutionGraph.tsx
@@ -1,0 +1,226 @@
+'use client';
+
+import React, { useMemo, useRef, useCallback } from 'react';
+import {
+  ReactFlow,
+  Background,
+  Controls,
+  Handle,
+  Position,
+  NodeProps,
+  Node,
+  Edge,
+  BackgroundVariant,
+} from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
+import {
+  forceSimulation, forceManyBody, forceLink, forceCenter, forceCollide,
+  type SimulationNodeDatum, type SimulationLinkDatum,
+} from 'd3-force';
+import { ExecutionRecord, ExecutionKind, ExecutionStatus } from '../domain/models/executions';
+
+// Agent-centric graph: agent/type hubs (QA, Security, Deploy, phases…) link to the
+// features they ran against. An edge aggregates every run for that (agent, feature)
+// pair — thickness ∝ run count, colour = the most recent run's status.
+
+type ExecutionGraphProps = {
+  executions: ExecutionRecord[];
+  theme: 'light' | 'dark';
+  onOpenLog: (id: string) => void;
+};
+
+const STATUS_HEX: Record<ExecutionStatus, string> = {
+  running: '#3b82f6',
+  passed: '#22c55e',
+  failed: '#ef4444',
+};
+const KIND_HEX: Record<ExecutionKind, string> = {
+  phase: '#6366f1',   // indigo
+  persona: '#8b5cf6', // violet
+  devops: '#0ea5e9',  // sky
+};
+const KIND_LABEL: Record<ExecutionKind, string> = { phase: 'Phase', persona: 'Persona', devops: 'DevOps' };
+
+const radiusFor = (runs: number) => 16 + Math.min(22, Math.sqrt(runs) * 6);
+const FEATURE_HEX = '#71717a'; // zinc-500
+const WORKSPACE_KEY = '__workspace__';
+
+type AgentMeta = { id: string; kind: ExecutionKind; label: string; runs: number; lastStatus: ExecutionStatus; lastAt: number; running: boolean };
+type FeatureMeta = { id: string; label: string; runs: number; running: boolean };
+type LinkMeta = { id: string; source: string; target: string; count: number; lastStatus: ExecutionStatus; lastAt: number; lastExecId: string; running: boolean };
+
+// --- Custom nodes: a centered hidden handle makes ReactFlow draw straight edges
+// from node centre to node centre; the node body (rendered above edges) hides the
+// overlapping segment, giving the clean Obsidian-style center-to-center look. ---
+const hiddenHandle: React.CSSProperties = {
+  left: '50%', top: '50%', transform: 'translate(-50%,-50%)',
+  width: 1, height: 1, minWidth: 0, minHeight: 0, border: 'none', background: 'transparent', opacity: 0,
+};
+
+const Handles = () => (
+  <>
+    <Handle type="target" position={Position.Top} id="c" style={hiddenHandle} isConnectable={false} />
+    <Handle type="source" position={Position.Top} id="c" style={hiddenHandle} isConnectable={false} />
+  </>
+);
+
+const AgentNode: React.FC<NodeProps> = ({ data }) => {
+  const d = data as unknown as AgentMeta;
+  const size = radiusFor(d.runs) * 2;
+  const color = KIND_HEX[d.kind];
+  return (
+    <div className="relative flex items-center justify-center rounded-full font-semibold text-white shadow-md"
+      style={{
+        width: size, height: size, background: color,
+        boxShadow: d.running ? `0 0 0 4px ${color}55` : undefined,
+      }}
+      title={`${KIND_LABEL[d.kind]} · ${d.label} · ${d.runs} run(s)`}
+    >
+      <Handles />
+      <span className="px-1 text-center leading-tight" style={{ fontSize: Math.max(8, size / 6) }}>{d.label}</span>
+      {d.running && <span className="absolute inset-0 rounded-full animate-ping" style={{ boxShadow: `0 0 0 3px ${color}` }} />}
+    </div>
+  );
+};
+
+const FeatureNode: React.FC<NodeProps> = ({ data }) => {
+  const d = data as unknown as FeatureMeta;
+  return (
+    <div className="relative flex items-center justify-center rounded-lg border-2 px-3 py-2 font-bold shadow-md bg-white dark:bg-zinc-900 text-zinc-800 dark:text-zinc-100"
+      style={{ borderColor: FEATURE_HEX, boxShadow: d.running ? `0 0 0 4px ${FEATURE_HEX}44` : undefined }}
+      title={`${d.label} · ${d.runs} run(s)`}
+    >
+      <Handles />
+      <span className="text-[11px] max-w-[140px] truncate">{d.label}</span>
+    </div>
+  );
+};
+
+const nodeTypes = { agent: AgentNode, feature: FeatureNode };
+
+export const ExecutionGraph: React.FC<ExecutionGraphProps> = ({ executions, theme, onOpenLog }) => {
+  const posRef = useRef<Map<string, { x: number; y: number }>>(new Map());
+
+  // 1. Aggregate executions into agent hubs, feature hubs, and weighted links.
+  const graph = useMemo(() => {
+    const agents = new Map<string, AgentMeta>();
+    const features = new Map<string, FeatureMeta>();
+    const links = new Map<string, LinkMeta>();
+
+    for (const e of executions) {
+      const featKey = e.feature || WORKSPACE_KEY;
+      const featLabel = e.feature || 'Workspace';
+      const agentKey = `${e.kind}:${e.agentId || e.phase || e.label}`;
+      const running = e.status === 'running';
+
+      const a = agents.get(agentKey) || { id: agentKey, kind: e.kind, label: e.label, runs: 0, lastStatus: e.status, lastAt: 0, running: false };
+      a.runs += 1; a.running = a.running || running;
+      if (e.startedAt >= a.lastAt) { a.lastAt = e.startedAt; a.lastStatus = e.status; a.label = e.label; }
+      agents.set(agentKey, a);
+
+      const f = features.get(featKey) || { id: featKey, label: featLabel, runs: 0, running: false };
+      f.runs += 1; f.running = f.running || running;
+      features.set(featKey, f);
+
+      const linkKey = `${agentKey}__${featKey}`;
+      const l = links.get(linkKey) || { id: linkKey, source: agentKey, target: featKey, count: 0, lastStatus: e.status, lastAt: 0, lastExecId: e.id, running: false };
+      l.count += 1; l.running = l.running || running;
+      if (e.startedAt >= l.lastAt) { l.lastAt = e.startedAt; l.lastStatus = e.status; l.lastExecId = e.id; }
+      links.set(linkKey, l);
+    }
+    return { agents: [...agents.values()], features: [...features.values()], links: [...links.values()] };
+  }, [executions]);
+
+  // 2. Run a force layout when the topology (node/edge set) changes — NOT on mere
+  // status/count updates — so live updates restyle without re-shuffling the graph.
+  const layoutSig = useMemo(() => {
+    const ids = [...graph.agents.map(a => a.id), ...graph.features.map(f => f.id)].sort().join('|');
+    const ls = graph.links.map(l => `${l.source}>${l.target}`).sort().join('|');
+    return `${ids}#${ls}`;
+  }, [graph]);
+
+  const positions = useMemo(() => {
+    type SN = SimulationNodeDatum & { id: string; r: number };
+    const allNodes: SN[] = [
+      ...graph.agents.map(a => ({ id: a.id, r: radiusFor(a.runs) })),
+      ...graph.features.map(f => ({ id: f.id, r: 28 })),
+    ];
+    // Seed from cached positions so existing nodes stay put across re-layouts.
+    for (const n of allNodes) {
+      const p = posRef.current.get(n.id);
+      n.x = p?.x ?? (Math.random() - 0.5) * 400;
+      n.y = p?.y ?? (Math.random() - 0.5) * 400;
+    }
+    const simLinks: SimulationLinkDatum<SN>[] = graph.links.map(l => ({ source: l.source, target: l.target }));
+    const sim = forceSimulation(allNodes)
+      .force('charge', forceManyBody().strength(-340))
+      .force('link', forceLink<SN, SimulationLinkDatum<SN>>(simLinks).id(d => d.id).distance(130).strength(0.5))
+      .force('center', forceCenter(0, 0))
+      .force('collide', forceCollide<SN>().radius(d => d.r + 12))
+      .stop();
+    sim.tick(320);
+    const map = new Map<string, { x: number; y: number }>();
+    for (const n of allNodes) map.set(n.id, { x: n.x ?? 0, y: n.y ?? 0 });
+    posRef.current = map;
+    return map;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [layoutSig]);
+
+  // 3. Build ReactFlow nodes/edges (positions from the cached layout, styling fresh).
+  const nodes: Node[] = useMemo(() => {
+    const out: Node[] = [];
+    for (const a of graph.agents) {
+      const p = positions.get(a.id) || { x: 0, y: 0 };
+      out.push({ id: a.id, type: 'agent', position: p, data: a as any, draggable: true });
+    }
+    for (const f of graph.features) {
+      const p = positions.get(f.id) || { x: 0, y: 0 };
+      out.push({ id: f.id, type: 'feature', position: p, data: f as any, draggable: true });
+    }
+    return out;
+  }, [graph, positions]);
+
+  const edges: Edge[] = useMemo(() => graph.links.map(l => ({
+    id: l.id,
+    source: l.source,
+    target: l.target,
+    sourceHandle: 'c',
+    targetHandle: 'c',
+    type: 'straight',
+    animated: l.running,
+    data: { lastExecId: l.lastExecId },
+    style: { stroke: STATUS_HEX[l.lastStatus], strokeWidth: Math.min(5, 1.2 + l.count * 0.8), opacity: 0.85 },
+  })), [graph.links]);
+
+  const onEdgeClick = useCallback((_: React.MouseEvent, edge: Edge) => {
+    const id = (edge.data as any)?.lastExecId;
+    if (id) onOpenLog(id);
+  }, [onOpenLog]);
+
+  if (executions.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-full text-xs text-zinc-500 italic">
+        No executions yet — run a phase, the review gate, or a DevOps agent to populate the graph.
+      </div>
+    );
+  }
+
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      nodeTypes={nodeTypes}
+      onEdgeClick={onEdgeClick}
+      fitView
+      minZoom={0.2}
+      maxZoom={2.5}
+      proOptions={{ hideAttribution: true }}
+      colorMode={theme}
+    >
+      <Background variant={BackgroundVariant.Dots} gap={20} size={1} color={theme === 'dark' ? '#27272a' : '#e4e4e7'} />
+      <Controls showInteractive={false} />
+    </ReactFlow>
+  );
+};
+
+export default ExecutionGraph;

--- a/src/components/ExecutionsView.tsx
+++ b/src/components/ExecutionsView.tsx
@@ -1,0 +1,247 @@
+'use client';
+
+import React, { useState } from 'react';
+import {
+  Activity, Rocket, Radar, Wrench, Loader2, CheckCircle2, XCircle,
+  Layers, ShieldCheck, X, FileText, List, Share2, Maximize2, Minimize2,
+} from 'lucide-react';
+import { WorkflowState } from '../domain/models/types';
+import { ExecutionRecord, ExecutionKind, ExecutionStatus } from '../domain/models/executions';
+import { DevOpsAgent, DevOpsCategory } from '../domain/models/devopsAgents';
+import { fmtUSD, fmtTokens, fmtDuration, fmtClock } from '../lib/format';
+import ExecutionGraph from './ExecutionGraph';
+
+type ExecutionsViewProps = {
+  state: WorkflowState;
+  executions: ExecutionRecord[];
+  devopsAgents: DevOpsAgent[];
+  runningDevOps: string | null; // agent id currently being launched
+  onRunDevOps: (agentId: string) => void;
+  theme: 'light' | 'dark';
+};
+
+const statusChip = (status: ExecutionStatus): string => {
+  switch (status) {
+    case 'running': return 'text-blue-500 bg-blue-500/10 animate-pulse';
+    case 'passed': return 'text-green-500 bg-green-500/10';
+    case 'failed': return 'text-red-500 bg-red-500/10';
+    default: return 'text-zinc-400 bg-zinc-100 dark:bg-zinc-900';
+  }
+};
+
+const StatusIcon: React.FC<{ status: ExecutionStatus }> = ({ status }) => {
+  if (status === 'running') return <Loader2 size={13} className="animate-spin" />;
+  if (status === 'passed') return <CheckCircle2 size={13} />;
+  if (status === 'failed') return <XCircle size={13} />;
+  return null;
+};
+
+const kindMeta: Record<ExecutionKind, { label: string; icon: React.ReactNode }> = {
+  phase: { label: 'Phase', icon: <Layers size={12} /> },
+  persona: { label: 'Persona', icon: <ShieldCheck size={12} /> },
+  devops: { label: 'DevOps', icon: <Rocket size={12} /> },
+};
+
+const devopsIcon = (category: DevOpsCategory) => {
+  if (category === 'monitor') return <Radar size={13} />;
+  if (category === 'troubleshoot') return <Wrench size={13} />;
+  return <Rocket size={13} />;
+};
+
+export const ExecutionsView: React.FC<ExecutionsViewProps> = ({
+  state, executions, devopsAgents, runningDevOps, onRunDevOps, theme,
+}) => {
+  const [logId, setLogId] = useState<string | null>(null);
+  const [log, setLog] = useState<string>('');
+  const [logLoading, setLogLoading] = useState(false);
+  const [mode, setMode] = useState<'list' | 'graph'>('list');
+  const [graphMax, setGraphMax] = useState(false);
+
+  const activeFeature = state.activeFeatureName;
+  const enabledDevOps = devopsAgents.filter(a => a.enabled);
+
+  const openLog = async (id: string) => {
+    setLogId(id);
+    setLog('');
+    setLogLoading(true);
+    try {
+      const res = await fetch(`/api/executions/log?id=${encodeURIComponent(id)}`);
+      const data = await res.json();
+      setLog(data.log || '(no output captured)');
+    } catch (e: any) {
+      setLog(`Failed to load log: ${e.message}`);
+    } finally {
+      setLogLoading(false);
+    }
+  };
+
+  const modeToggle = (
+    <div className="flex items-center bg-zinc-100 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-md p-0.5">
+      <button
+        onClick={() => setMode('list')}
+        className={`px-2 py-1 rounded transition text-[11px] flex items-center gap-1 font-semibold ${mode === 'list' ? 'bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-50 shadow-sm' : 'text-zinc-500 hover:text-zinc-800 dark:hover:text-zinc-200'}`}
+      >
+        <List size={12} /> List
+      </button>
+      <button
+        onClick={() => setMode('graph')}
+        className={`px-2 py-1 rounded transition text-[11px] flex items-center gap-1 font-semibold ${mode === 'graph' ? 'bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-50 shadow-sm' : 'text-zinc-500 hover:text-zinc-800 dark:hover:text-zinc-200'}`}
+      >
+        <Share2 size={12} /> Graph
+      </button>
+    </div>
+  );
+
+  const devopsToolbar = (
+    <div className="mb-4 shrink-0">
+      <div className="flex items-center gap-2 mb-2">
+        <h3 className="text-xs font-bold text-zinc-600 dark:text-zinc-400 uppercase tracking-wider">DevOps — run on demand</h3>
+        <span className="text-[10px] text-zinc-400">
+          {activeFeature ? `Target: ${activeFeature}` : 'Workspace-wide (no active feature)'}
+        </span>
+      </div>
+      {enabledDevOps.length === 0 ? (
+        <p className="text-[11px] text-zinc-500 italic">
+          No DevOps agents enabled. Enable them in <span className="font-semibold">Agents → DevOps</span>, and install the
+          {' '}<span className="font-mono">DevOps Agents</span> extension from the Extensions panel.
+        </p>
+      ) : (
+        <div className="flex flex-wrap gap-2">
+          {enabledDevOps.map(a => (
+            <button
+              key={a.id}
+              onClick={() => onRunDevOps(a.id)}
+              disabled={runningDevOps !== null}
+              className="flex items-center gap-1.5 px-3 py-1.5 bg-black dark:bg-white text-white dark:text-black rounded-lg text-[11px] font-semibold hover:opacity-90 transition disabled:opacity-50"
+              title={a.description || a.command}
+            >
+              {runningDevOps === a.id ? <Loader2 size={13} className="animate-spin" /> : devopsIcon(a.category)}
+              {a.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+
+  const listBody = (
+    executions.length === 0 ? (
+      <div className="text-xs text-zinc-500 italic py-8 text-center">
+        No executions recorded yet. Run a phase, the review gate, or a DevOps agent to see runs here.
+        <div className="mt-1 text-[10px] not-italic text-zinc-400">
+          Spec-agent hooks run inside the specify CLI and appear via the specification phase run.
+        </div>
+      </div>
+    ) : (
+      <div className="space-y-1.5">
+        {executions.map(e => {
+          const duration = e.completedAt && e.startedAt ? e.completedAt - e.startedAt : e.cost?.durationMs;
+          return (
+            <button
+              key={e.id}
+              onClick={() => openLog(e.id)}
+              className="w-full flex items-center gap-3 p-2.5 bg-white dark:bg-zinc-950 border border-zinc-200 dark:border-zinc-800 rounded-lg hover:bg-zinc-50 dark:hover:bg-zinc-900 transition text-left"
+            >
+              <span className={`flex items-center gap-1 text-[10px] font-bold px-1.5 py-0.5 rounded shrink-0 ${statusChip(e.status)}`}>
+                <StatusIcon status={e.status} />
+                {e.status}
+              </span>
+              <span className="flex items-center gap-1 text-[9px] font-semibold text-zinc-500 uppercase shrink-0 w-16">
+                {kindMeta[e.kind].icon}{kindMeta[e.kind].label}
+              </span>
+              <div className="min-w-0 flex-1">
+                <div className="text-sm font-semibold text-zinc-900 dark:text-white truncate">{e.label}</div>
+                <div className="text-[10px] text-zinc-500 font-mono truncate">
+                  {e.feature || 'workspace'}{e.command ? ` · ${e.command}` : ''}
+                </div>
+              </div>
+              <div className="flex items-center gap-3 text-[10px] text-zinc-500 shrink-0">
+                <span title="started">{fmtClock(e.startedAt)}</span>
+                {typeof duration === 'number' && <span title="duration">{fmtDuration(duration)}</span>}
+                {e.cost?.costUSD !== undefined && <span title="cost">{fmtUSD(e.cost.costUSD)}</span>}
+                {e.cost?.totalTokens !== undefined && <span title="tokens">{fmtTokens(e.cost.totalTokens)} tok</span>}
+                {typeof e.exitCode === 'number' && <span className="font-mono" title="exit code">#{e.exitCode}</span>}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    )
+  );
+
+  return (
+    <div className="w-full h-full flex flex-col px-6 py-5">
+      {devopsToolbar}
+
+      {/* Header + mode toggle */}
+      <div className="flex items-center gap-2 mb-3 shrink-0">
+        <Activity size={15} className="text-zinc-500" />
+        <h3 className="text-xs font-bold text-zinc-600 dark:text-zinc-400 uppercase tracking-wider">Agent executions</h3>
+        <span className="text-[10px] text-zinc-400">{executions.length} run{executions.length !== 1 ? 's' : ''}</span>
+        <div className="ml-auto flex items-center gap-2">
+          {mode === 'graph' && (
+            <button
+              onClick={() => setGraphMax(true)}
+              className="p-1.5 rounded text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-100 hover:bg-zinc-100 dark:hover:bg-zinc-900 transition"
+              title="Maximize graph (full screen)"
+            >
+              <Maximize2 size={14} />
+            </button>
+          )}
+          {modeToggle}
+        </div>
+      </div>
+
+      {/* Body */}
+      <div className={mode === 'list' ? 'flex-1 min-h-0 overflow-y-auto' : 'flex-1 min-h-0 rounded-lg border border-zinc-200 dark:border-zinc-800 overflow-hidden'}>
+        {mode === 'list'
+          ? listBody
+          : graphMax
+            ? <div className="flex items-center justify-center h-full text-xs text-zinc-500 italic">Graph maximized — full screen.</div>
+            : <ExecutionGraph executions={executions} theme={theme} onOpenLog={openLog} />}
+      </div>
+
+      {/* Maximized graph overlay (full width + full height) */}
+      {graphMax && (
+        <div className="fixed inset-0 z-40 bg-white dark:bg-black flex flex-col">
+          <div className="flex items-center gap-2 px-5 py-2.5 border-b border-zinc-200 dark:border-zinc-800 bg-zinc-50/70 dark:bg-zinc-950/40 shrink-0">
+            <Share2 size={14} className="text-zinc-500" />
+            <span className="text-xs font-bold text-zinc-700 dark:text-zinc-200 uppercase tracking-wider">Execution graph</span>
+            <span className="text-[10px] text-zinc-400">{executions.length} runs</span>
+            <button
+              onClick={() => setGraphMax(false)}
+              className="ml-auto p-1.5 rounded text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-100 hover:bg-zinc-100 dark:hover:bg-zinc-900 transition"
+              title="Restore"
+            >
+              <Minimize2 size={15} />
+            </button>
+          </div>
+          <div className="flex-1 min-h-0">
+            <ExecutionGraph executions={executions} theme={theme} onOpenLog={openLog} />
+          </div>
+        </div>
+      )}
+
+      {/* Log drawer (above the maximized overlay) */}
+      {logId && (
+        <div className="fixed inset-0 bg-black/50 dark:bg-black/80 backdrop-blur-sm z-50 flex items-center justify-center p-4" onClick={() => setLogId(null)}>
+          <div className="bg-white dark:bg-zinc-950 border border-zinc-200 dark:border-zinc-800 w-full max-w-3xl h-[80vh] rounded-xl flex flex-col overflow-hidden shadow-2xl" onClick={ev => ev.stopPropagation()}>
+            <header className="px-5 py-3 border-b border-zinc-200 dark:border-zinc-800 flex justify-between items-center bg-zinc-50 dark:bg-zinc-900/50">
+              <div className="flex items-center gap-2 text-zinc-900 dark:text-white">
+                <FileText size={15} /> <span className="text-sm font-bold">Execution log</span>
+              </div>
+              <button onClick={() => setLogId(null)} className="p-1.5 hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-lg text-zinc-500 transition">
+                <X size={16} />
+              </button>
+            </header>
+            <pre className="flex-1 overflow-auto p-4 bg-black text-zinc-300 font-mono text-[11px] leading-relaxed whitespace-pre-wrap select-text">
+              {logLoading ? 'Loading…' : log}
+            </pre>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ExecutionsView;

--- a/src/components/ExtensionsPanel.tsx
+++ b/src/components/ExtensionsPanel.tsx
@@ -5,6 +5,7 @@ import { Package, Download, Trash2, Power, AlertTriangle, Terminal } from 'lucid
 import { InstalledExtension, BundledExtension } from '../domain/models/extensions';
 
 export type ExtensionAction =
+  | { action: 'install-cli' }
   | { action: 'install-bundled'; id: string }
   | { action: 'install-community'; id: string; fromUrl?: string; priority?: number }
   | { action: 'remove'; id: string }
@@ -59,8 +60,15 @@ export const ExtensionsPanel: React.FC<ExtensionsPanelProps> = ({ available, ins
           <AlertTriangle size={14} className="shrink-0 mt-0.5" />
           <div>
             <p className="font-semibold">The <span className="font-mono">specify</span> CLI was not found.</p>
-            <p className="mt-1">Install it to manage extensions:</p>
-            <pre className="mt-1 font-mono text-[11px] whitespace-pre-wrap">uv tool install specify-cli --from git+https://github.com/github/spec-kit.git</pre>
+            <p className="mt-1">Installs from the spec-kit GitHub source (no git needed) into the project's local <span className="font-mono">.venv</span> if present, otherwise globally. Requires <span className="font-mono">uv</span>:</p>
+            <pre className="mt-1 font-mono text-[11px] whitespace-pre-wrap">uv pip install &quot;specify-cli @ https://github.com/github/spec-kit/archive/refs/heads/main.zip&quot;</pre>
+            <button
+              onClick={() => run('install-cli', { action: 'install-cli' })}
+              disabled={busy === 'install-cli'}
+              className="mt-2 flex items-center gap-1.5 px-3 py-1.5 bg-amber-600 text-white rounded-lg text-[11px] font-semibold hover:opacity-90 transition disabled:opacity-50"
+            >
+              <Download size={13} /> {busy === 'install-cli' ? 'Installing CLI…' : 'Install specify CLI'}
+            </button>
           </div>
         </div>
       )}

--- a/src/components/HumanReviewModal.tsx
+++ b/src/components/HumanReviewModal.tsx
@@ -11,6 +11,7 @@ import { PhaseState, PersonaState, CostMetadata } from '../domain/models/types';
 import dynamic from 'next/dynamic';
 import { FileTree, TreeNode } from './FileTree';
 import { MarkdownPreview } from './MarkdownPreview';
+import { fmtUSD, fmtTokens, fmtDuration } from '../lib/format';
 
 // Lazy-loaded so react-syntax-highlighter only ships when a code file is opened.
 const CodeViewer = dynamic(() => import('./CodeViewer').then((m) => m.CodeViewer), {
@@ -19,16 +20,6 @@ const CodeViewer = dynamic(() => import('./CodeViewer').then((m) => m.CodeViewer
 });
 
 const isMarkdownPath = (p: string) => /\.(md|markdown)$/i.test(p);
-
-// Cost/usage formatting helpers for the review portal.
-const fmtUSD = (usd: number) => `$${usd < 0.01 ? usd.toFixed(4) : usd.toFixed(2)}`;
-const fmtTokens = (n: number) => (n >= 1000 ? `${(n / 1000).toFixed(1)}k` : `${n}`);
-const fmtDuration = (ms: number) => {
-  const s = Math.round(ms / 1000);
-  if (s < 60) return `${s}s`;
-  const m = Math.floor(s / 60);
-  return `${m}m ${s % 60}s`;
-};
 
 type HumanReviewModalProps = {
   isOpen: boolean;

--- a/src/components/PersonaEditorModal.tsx
+++ b/src/components/PersonaEditorModal.tsx
@@ -143,7 +143,7 @@ export const PersonaEditorModal: React.FC<PersonaEditorModalProps> = ({
                 value={command}
                 onChange={(e) => setCommand(e.target.value)}
                 className={`${input} font-mono`}
-                placeholder="e.g. /speckit.review.qa"
+                placeholder="e.g. /speckit.personas.qa"
               />
             </div>
             <div className="flex items-center h-full pt-4">

--- a/src/components/SpecAgentEditorModal.tsx
+++ b/src/components/SpecAgentEditorModal.tsx
@@ -42,7 +42,7 @@ export const SpecAgentEditorModal: React.FC<SpecAgentEditorModalProps> = ({ isOp
 
   const handleSave = () => {
     const id = agent?.id || slugify(label);
-    const command = agent?.command || `speckit.spec.${id}`;
+    const command = agent?.command || `speckit.spec-agents.${id}`;
     onSave({
       id,
       label: label.trim() || 'Untitled Agent',
@@ -97,7 +97,7 @@ export const SpecAgentEditorModal: React.FC<SpecAgentEditorModalProps> = ({ isOp
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
               <label className={labelCls}>Slash Command</label>
-              <input className={`${input} font-mono disabled:opacity-60`} value={agent?.command || (label ? `speckit.spec.${slugify(label)}` : '')} disabled placeholder="speckit.spec.<id>" />
+              <input className={`${input} font-mono disabled:opacity-60`} value={agent?.command || (label ? `speckit.spec-agents.${slugify(label)}` : '')} disabled placeholder="speckit.spec-agents.<id>" />
             </div>
             <div>
               <label className={labelCls}>Priority (lower runs first)</label>

--- a/src/domain/models/devopsAgents.ts
+++ b/src/domain/models/devopsAgents.ts
@@ -1,0 +1,52 @@
+// An operational (DevOps) agent run on demand from the Executions view. Built-in
+// agents are backed by the bundled spec-kit-devops extension; per-agent model and
+// systemPrompt are passed to the agent CLI as env vars at run time.
+export type DevOpsCategory = 'deploy' | 'monitor' | 'troubleshoot';
+
+export type DevOpsAgent = {
+  id: string;
+  label: string;
+  command: string; // slash command, e.g. "speckit.devops.deploy"
+  category: DevOpsCategory;
+  description?: string;
+  model?: string;
+  systemPrompt?: string;
+  enabled: boolean;
+  builtin?: boolean;
+};
+
+export type DevOpsAgentsFile = { agents: DevOpsAgent[] };
+
+export const DEVOPS_AGENTS_EXTENSION_ID = 'devops';
+
+export const DEFAULT_DEVOPS_AGENTS: DevOpsAgentsFile = {
+  agents: [
+    {
+      id: 'devops-deploy',
+      label: 'Deploy',
+      command: 'speckit.devops.deploy',
+      category: 'deploy',
+      description: 'Ships the approved implementation and verifies the release.',
+      enabled: true,
+      builtin: true,
+    },
+    {
+      id: 'devops-monitor',
+      label: 'Monitor',
+      command: 'speckit.devops.monitor',
+      category: 'monitor',
+      description: 'Inspects post-deploy health, metrics and logs.',
+      enabled: true,
+      builtin: true,
+    },
+    {
+      id: 'devops-troubleshoot',
+      label: 'Troubleshoot',
+      command: 'speckit.devops.troubleshoot',
+      category: 'troubleshoot',
+      description: 'Diagnoses incidents and proposes remediation.',
+      enabled: true,
+      builtin: true,
+    },
+  ],
+};

--- a/src/domain/models/executions.ts
+++ b/src/domain/models/executions.ts
@@ -1,0 +1,46 @@
+import { WorkflowPhase, CostMetadata } from './types';
+
+// Every tracked agent run that this process orchestrates: a workflow phase, a
+// review-gate persona, or an on-demand DevOps agent. (Spec-agent hook runs happen
+// inside the specify CLI subprocess and are not individually tracked here.)
+export type ExecutionKind = 'phase' | 'persona' | 'devops';
+
+export type ExecutionStatus =
+  | 'running' // process spawned, not yet exited
+  | 'passed'  // clean/verdict pass
+  | 'failed'; // non-zero exit / verdict fail
+
+// A persisted record of one agent run. Stored append-only as JSONL; a run writes a
+// 'running' snapshot at start and a patch at finish, merged by id on read.
+export type ExecutionRecord = {
+  id: string;
+  kind: ExecutionKind;
+  feature: string | null;
+  phase?: WorkflowPhase;
+  agentId?: string; // persona id or devops agent id
+  label: string;
+  command?: string;
+  status: ExecutionStatus;
+  startedAt: number; // epoch ms
+  seq?: number; // monotonic per-process tiebreaker for runs started in the same ms
+  completedAt?: number; // epoch ms
+  exitCode?: number;
+  cost?: CostMetadata;
+  logPath: string; // workspace-relative path to the captured log
+};
+
+// Fields supplied when a run starts; the store assigns id/startedAt/status/logPath.
+export type ExecutionStartInput = {
+  kind: ExecutionKind;
+  feature: string | null;
+  phase?: WorkflowPhase;
+  agentId?: string;
+  label: string;
+  command?: string;
+};
+
+export type ExecutionFinishPatch = {
+  status: ExecutionStatus;
+  exitCode?: number;
+  cost?: CostMetadata;
+};

--- a/src/domain/models/extensions.ts
+++ b/src/domain/models/extensions.ts
@@ -33,4 +33,10 @@ export const BUNDLED_EXTENSIONS: BundledExtension[] = [
     description: 'Specification-phase agents: Product Owner, Architecture, Technical Refinement, Consolidate.',
     dir: 'spec-kit-spec-agents',
   },
+  {
+    id: 'devops',
+    label: 'DevOps Agents',
+    description: 'On-demand operational agents: Deploy, post-deploy Monitoring, Troubleshooting.',
+    dir: 'spec-kit-devops',
+  },
 ];

--- a/src/domain/models/personas.ts
+++ b/src/domain/models/personas.ts
@@ -11,7 +11,7 @@ export const DEFAULT_PERSONAS: PersonaConfig[] = [
   {
     id: 'qa',
     label: 'QA',
-    command: '/speckit.review.qa',
+    command: '/speckit.personas.qa',
     enabled: true,
     model: 'gemini-2.5-flash',
     description: 'Automated quality assurance agent. Runs tests, verifies regression suite, and inspects validation logs.',
@@ -22,7 +22,7 @@ export const DEFAULT_PERSONAS: PersonaConfig[] = [
   {
     id: 'code-review',
     label: 'Code Review',
-    command: '/speckit.review.code',
+    command: '/speckit.personas.code',
     enabled: true,
     model: 'gemini-2.5-pro',
     description: 'Automated code standard and architectural reviewer. Validates SOLID patterns and code complexity.',
@@ -33,7 +33,7 @@ export const DEFAULT_PERSONAS: PersonaConfig[] = [
   {
     id: 'security',
     label: 'Security',
-    command: '/speckit.review.security',
+    command: '/speckit.personas.security',
     enabled: true,
     model: 'claude-3-5-sonnet',
     description: 'Automated security compliance agent. Scans for hardcoded credentials, dependency CVEs, and OWASP vulnerabilities.',
@@ -44,7 +44,7 @@ export const DEFAULT_PERSONAS: PersonaConfig[] = [
   {
     id: 'tech-lead',
     label: 'Tech Lead',
-    command: '/speckit.review.techlead',
+    command: '/speckit.personas.techlead',
     enabled: true,
     model: 'gemini-2.5-pro',
     description: 'Tech Lead agent responsible for final signature sign-off. Aggregates reviews and signs the implementation gate.',

--- a/src/domain/models/specAgents.ts
+++ b/src/domain/models/specAgents.ts
@@ -4,7 +4,7 @@
 export type SpecAgent = {
   id: string;
   label: string;
-  command: string; // slash command, e.g. "speckit.spec.po"
+  command: string; // slash command, e.g. "speckit.spec-agents.po"
   description?: string;
   model?: string;
   systemPrompt?: string; // used for custom agents
@@ -20,9 +20,9 @@ export const SPEC_AGENTS_EXTENSION_ID = 'spec-agents';
 
 export const DEFAULT_SPEC_AGENTS: SpecAgentsFile = {
   agents: [
-    { id: 'spec-po', label: 'Product Owner', command: 'speckit.spec.po', description: 'Business value, scope and acceptance criteria.', enabled: true, optional: true, priority: 10, builtin: true },
-    { id: 'spec-architecture', label: 'Architecture', command: 'speckit.spec.architecture', description: 'Technical risks, NFRs and constraints.', enabled: true, optional: true, priority: 20, builtin: true },
-    { id: 'spec-refine', label: 'Technical Refinement', command: 'speckit.spec.refine', description: 'Requirement clarity, ambiguities and testability.', enabled: true, optional: true, priority: 30, builtin: true },
-    { id: 'spec-consolidate', label: 'Consolidate (Lead)', command: 'speckit.spec.consolidate', description: 'Merge contributions into spec.md.', enabled: true, optional: true, priority: 90, builtin: true },
+    { id: 'spec-po', label: 'Product Owner', command: 'speckit.spec-agents.po', description: 'Business value, scope and acceptance criteria.', enabled: true, optional: true, priority: 10, builtin: true },
+    { id: 'spec-architecture', label: 'Architecture', command: 'speckit.spec-agents.architecture', description: 'Technical risks, NFRs and constraints.', enabled: true, optional: true, priority: 20, builtin: true },
+    { id: 'spec-refine', label: 'Technical Refinement', command: 'speckit.spec-agents.refine', description: 'Requirement clarity, ambiguities and testability.', enabled: true, optional: true, priority: 30, builtin: true },
+    { id: 'spec-consolidate', label: 'Consolidate (Lead)', command: 'speckit.spec-agents.consolidate', description: 'Merge contributions into spec.md.', enabled: true, optional: true, priority: 90, builtin: true },
   ],
 };

--- a/src/domain/models/types.ts
+++ b/src/domain/models/types.ts
@@ -48,7 +48,7 @@ export type PersonaState = {
 export type PersonaConfig = {
   id: PersonaId;
   label: string;    // "QA", "Code Review", "Security", "Tech Lead"
-  command: string;  // extension slash command, e.g. "/speckit.review.qa"
+  command: string;  // extension slash command, e.g. "/speckit.personas.qa"
   enabled: boolean;
   model?: string;
   systemPrompt?: string;

--- a/src/domain/ports/out/AgentRunnerPort.ts
+++ b/src/domain/ports/out/AgentRunnerPort.ts
@@ -1,4 +1,5 @@
 import { WorkflowPhase, AgentConfig, PersonaConfig, PersonaId, CostMetadata } from '../../models/types';
+import { DevOpsAgent } from '../../models/devopsAgents';
 
 export interface AgentRunnerPort {
   runPhase(
@@ -16,6 +17,16 @@ export interface AgentRunnerPort {
     workspacePath: string,
     featureName: string,
     persona: PersonaConfig,
+    agentConfig: AgentConfig,
+    onData?: (text: string) => void,
+    onCost?: (cost: CostMetadata) => void
+  ): Promise<number>;
+  // Runs an on-demand DevOps agent (deploy/monitor/troubleshoot) as its own tracked
+  // CLI process. featureName may be null for a workspace-wide run.
+  runDevOps(
+    workspacePath: string,
+    featureName: string | null,
+    agent: DevOpsAgent,
     agentConfig: AgentConfig,
     onData?: (text: string) => void,
     onCost?: (cost: CostMetadata) => void

--- a/src/domain/ports/out/DevOpsAgentRepositoryPort.ts
+++ b/src/domain/ports/out/DevOpsAgentRepositoryPort.ts
@@ -1,0 +1,7 @@
+import { DevOpsAgentsFile } from '../../models/devopsAgents';
+
+export interface DevOpsAgentRepositoryPort {
+  // Reads/writes the roster at .specify/devops-agents.yaml (DEFAULT_DEVOPS_AGENTS when absent).
+  getAgents(workspacePath: string): Promise<DevOpsAgentsFile>;
+  saveAgents(workspacePath: string, file: DevOpsAgentsFile): Promise<void>;
+}

--- a/src/domain/ports/out/ExecutionHistoryPort.ts
+++ b/src/domain/ports/out/ExecutionHistoryPort.ts
@@ -1,0 +1,18 @@
+import {
+  ExecutionRecord,
+  ExecutionStartInput,
+  ExecutionFinishPatch,
+} from '../../models/executions';
+
+export interface ExecutionHistoryPort {
+  // Create a 'running' record (assigns id/startedAt/logPath) and persist it.
+  start(workspacePath: string, input: ExecutionStartInput): Promise<ExecutionRecord>;
+  // Append captured output to the run's log file (best-effort).
+  appendLog(workspacePath: string, id: string, text: string): void;
+  // Persist the terminal status/exit/cost for a run.
+  finish(workspacePath: string, id: string, patch: ExecutionFinishPatch): Promise<void>;
+  // All records (merged), optionally filtered by feature, newest first.
+  list(workspacePath: string, filter?: { feature?: string }): Promise<ExecutionRecord[]>;
+  // The captured log text for a run ('' when absent).
+  readLog(workspacePath: string, id: string): Promise<string>;
+}

--- a/src/domain/ports/out/SpecifyCliPort.ts
+++ b/src/domain/ports/out/SpecifyCliPort.ts
@@ -1,8 +1,13 @@
 export type SpecifyRunResult = { code: number; output: string };
 
 export interface SpecifyCliPort {
-  // True when the `specify` CLI is available on PATH (or via SPECIFY_BIN).
-  isAvailable(): Promise<boolean>;
+  // True when the `specify` CLI is available — preferring the workspace's local
+  // venv, then PATH (or an explicit SPECIFY_BIN).
+  isAvailable(workspacePath?: string): Promise<boolean>;
   // Runs `specify <args>` in the workspace, capturing combined stdout/stderr.
   run(workspacePath: string, args: string[]): Promise<SpecifyRunResult>;
+  // Installs the `specify` CLI itself via `uv tool install` from the spec-kit
+  // GitHub source zip (no git required), capturing combined stdout/stderr.
+  // Resolves `uv` from the workspace's local venv when present.
+  installCli(workspacePath: string): Promise<SpecifyRunResult>;
 }

--- a/src/domain/services/WorkflowService.test.ts
+++ b/src/domain/services/WorkflowService.test.ts
@@ -2,12 +2,14 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { WorkflowService } from './WorkflowService';
 import { WorkspaceRepositoryPort } from '../ports/out/WorkspaceRepositoryPort';
 import { AgentRunnerPort } from '../ports/out/AgentRunnerPort';
+import { ExecutionHistoryPort } from '../ports/out/ExecutionHistoryPort';
 import { WorkflowState, FeatureWorkflow } from '../models/types';
 import { DEFAULT_PERSONAS } from '../models/personas';
 
 describe('WorkflowService', () => {
   let workspaceRepo: vi.Mocked<WorkspaceRepositoryPort>;
   let agentRunner: vi.Mocked<AgentRunnerPort>;
+  let executionHistory: vi.Mocked<ExecutionHistoryPort>;
   let service: WorkflowService;
 
   const mockState: WorkflowState = {
@@ -42,7 +44,15 @@ describe('WorkflowService', () => {
       stop: vi.fn()
     } as any;
 
-    service = new WorkflowService(workspaceRepo, agentRunner);
+    executionHistory = {
+      start: vi.fn().mockImplementation(async (_ws, input) => ({ id: 'exec-1', logPath: '', startedAt: Date.now(), status: 'running', ...input })),
+      appendLog: vi.fn(),
+      finish: vi.fn().mockResolvedValue(undefined),
+      list: vi.fn().mockResolvedValue([]),
+      readLog: vi.fn().mockResolvedValue('')
+    } as any;
+
+    service = new WorkflowService(workspaceRepo, agentRunner, executionHistory);
   });
 
   it('should fetch workflow state', async () => {

--- a/src/domain/services/WorkflowService.ts
+++ b/src/domain/services/WorkflowService.ts
@@ -1,6 +1,7 @@
 import { WorkflowUseCases } from '../ports/in/WorkflowUseCases';
 import { WorkspaceRepositoryPort } from '../ports/out/WorkspaceRepositoryPort';
 import { AgentRunnerPort } from '../ports/out/AgentRunnerPort';
+import { ExecutionHistoryPort } from '../ports/out/ExecutionHistoryPort';
 import {
   WorkflowState,
   WorkflowPhase,
@@ -12,6 +13,8 @@ import {
   PersonaRunStatus,
   CostMetadata,
 } from '../models/types';
+import { ExecutionStartInput, ExecutionStatus } from '../models/executions';
+import { DevOpsAgent } from '../models/devopsAgents';
 import { orderPersonas, personaReportPath } from '../models/personas';
 
 const FEATURE_PHASES: WorkflowPhase[] = [
@@ -28,8 +31,39 @@ const FEATURE_PHASES: WorkflowPhase[] = [
 export class WorkflowService implements WorkflowUseCases {
   constructor(
     private workspaceRepo: WorkspaceRepositoryPort,
-    private agentRunner: AgentRunnerPort
+    private agentRunner: AgentRunnerPort,
+    private executionHistory: ExecutionHistoryPort
   ) {}
+
+  // Wraps an agent run with execution-history tracking: records a 'running' entry,
+  // tees the run's output to its log file, then persists the terminal status/exit/cost.
+  // Returns the exit code, captured cost, and resolved status.
+  private async recordRun(
+    workspacePath: string,
+    meta: ExecutionStartInput,
+    onData: ((text: string) => void) | undefined,
+    run: (onData: (text: string) => void, onCost: (cost: CostMetadata) => void) => Promise<number>,
+    resolveStatus?: (exitCode: number) => Promise<ExecutionStatus> | ExecutionStatus
+  ): Promise<{ exitCode: number; cost?: CostMetadata; status: ExecutionStatus }> {
+    const record = await this.executionHistory.start(workspacePath, meta);
+    const tee = (text: string) => {
+      this.executionHistory.appendLog(workspacePath, record.id, text);
+      onData?.(text);
+    };
+    let cost: CostMetadata | undefined;
+    let exitCode = 1;
+    try {
+      exitCode = await run(tee, (c) => { cost = c; });
+      const status: ExecutionStatus = resolveStatus
+        ? await resolveStatus(exitCode)
+        : exitCode === 0 ? 'passed' : 'failed';
+      await this.executionHistory.finish(workspacePath, record.id, { status, exitCode, cost });
+      return { exitCode, cost, status };
+    } catch (err) {
+      await this.executionHistory.finish(workspacePath, record.id, { status: 'failed', exitCode, cost });
+      throw err;
+    }
+  }
 
   async getWorkflowState(workspacePath: string): Promise<WorkflowState> {
     const state = await this.workspaceRepo.getWorkflowState(workspacePath);
@@ -74,15 +108,11 @@ export class WorkflowService implements WorkflowUseCases {
     await this.workspaceRepo.saveWorkflowState(workspacePath, state);
 
     try {
-      let runCost: CostMetadata | undefined;
-      const exitCode = await this.agentRunner.runPhase(
+      const { exitCode, cost: runCost } = await this.recordRun(
         workspacePath,
-        phase,
-        targetFeature,
-        agentConfig,
-        userPrompt,
+        { kind: 'phase', feature: targetFeature, phase, label: phase },
         onData,
-        (c) => { runCost = c; }
+        (d, c) => this.agentRunner.runPhase(workspacePath, phase, targetFeature, agentConfig, userPrompt, d, c)
       );
 
       // Re-read state in case files changed on disk during run
@@ -153,17 +183,15 @@ export class WorkflowService implements WorkflowUseCases {
 
       onData?.(`\r\n\x1b[36m=== Persona: ${persona.label} (${persona.command}) ===\x1b[0m\r\n`);
 
-      let personaCost: CostMetadata | undefined;
-      const exitCode = await this.agentRunner.runPersona(
+      const { cost: personaCost, status } = await this.recordRun(
         workspacePath,
-        featureName,
-        persona,
-        agentConfig,
+        { kind: 'persona', feature: featureName, phase: 'implementation', agentId: persona.id, label: persona.label, command: persona.command },
         onData,
-        (c) => { personaCost = c; }
+        (d, c) => this.agentRunner.runPersona(workspacePath, featureName, persona, agentConfig, d, c),
+        async (exit) => (await this.resolvePersonaVerdict(workspacePath, featureName, persona.id, exit)) as ExecutionStatus
       );
 
-      const verdict = await this.resolvePersonaVerdict(workspacePath, featureName, persona.id, exitCode);
+      const verdict = status as PersonaRunStatus;
       ps.status = verdict;
       if (personaCost) ps.cost = personaCost;
       await this.workspaceRepo.saveWorkflowState(workspacePath, state);
@@ -179,6 +207,25 @@ export class WorkflowService implements WorkflowUseCases {
     await this.workspaceRepo.saveWorkflowState(workspacePath, state);
     onData?.(`\r\n\x1b[32m✓ Review gate completo — pronto para aprovação.\x1b[0m\r\n`);
     return state;
+  }
+
+  // Runs an on-demand DevOps agent (deploy/monitor/troubleshoot). It does not change
+  // workflow/phase state — it's an operational action, fully tracked in the execution
+  // history. featureName may be null for a workspace-wide run.
+  async runDevOps(
+    workspacePath: string,
+    agent: DevOpsAgent,
+    featureName: string | null,
+    agentConfig: AgentConfig,
+    onData?: (text: string) => void
+  ): Promise<{ exitCode: number }> {
+    const { exitCode } = await this.recordRun(
+      workspacePath,
+      { kind: 'devops', feature: featureName, agentId: agent.id, label: agent.label, command: agent.command },
+      onData,
+      (d, c) => this.agentRunner.runDevOps(workspacePath, featureName, agent, agentConfig, d, c)
+    );
+    return { exitCode };
   }
 
   // A persona's verdict is read from its report (specs/<feature>/reviews/<id>.md):

--- a/src/domain/services/extensionsYaml.test.ts
+++ b/src/domain/services/extensionsYaml.test.ts
@@ -4,9 +4,9 @@ import { SpecAgentsFile } from '../models/specAgents';
 
 const file: SpecAgentsFile = {
   agents: [
-    { id: 'spec-refine', label: 'Refine', command: 'speckit.spec.refine', enabled: true, optional: true, priority: 30 },
-    { id: 'spec-po', label: 'PO', command: 'speckit.spec.po', enabled: true, optional: true, priority: 10 },
-    { id: 'spec-arch', label: 'Arch', command: 'speckit.spec.architecture', enabled: false, optional: true, priority: 20 },
+    { id: 'spec-refine', label: 'Refine', command: 'speckit.spec-agents.refine', enabled: true, optional: true, priority: 30 },
+    { id: 'spec-po', label: 'PO', command: 'speckit.spec-agents.po', enabled: true, optional: true, priority: 10 },
+    { id: 'spec-arch', label: 'Arch', command: 'speckit.spec-agents.architecture', enabled: false, optional: true, priority: 20 },
   ],
 };
 

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,17 @@
+// Cost/usage/time formatting helpers shared across run-cost UIs (review portal,
+// executions view).
+
+export const fmtUSD = (usd: number) => `$${usd < 0.01 ? usd.toFixed(4) : usd.toFixed(2)}`;
+
+export const fmtTokens = (n: number) => (n >= 1000 ? `${(n / 1000).toFixed(1)}k` : `${n}`);
+
+export const fmtDuration = (ms: number) => {
+  const s = Math.round(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  return `${m}m ${s % 60}s`;
+};
+
+// Compact clock time for a run's start (e.g. "14:03").
+export const fmtClock = (epochMs: number) =>
+  new Date(epochMs).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });


### PR DESCRIPTION
## Overview

Release **v0.4.0**. This branch bundles the recent work since v0.3.0:

1. **DevOps agents (on-demand)** — an operational agent profile (Deploy / Monitor / Troubleshoot).
2. **Agent Executions view** — full observability of every agent run (list + Obsidian-style graph) backed by a persisted run history.
3. **One-click `specify` CLI install** — venv-first, from the spec-kit GitHub source ZIP (no `git` required).
4. **Bundled-extension namespace fixes** — `personas` and `spec-agents` commands now pass the specify CLI's `speckit.<id>.<command>` validation.

## DevOps agents

- Bundled `spec-kit-devops` extension: `speckit.devops.deploy|monitor|troubleshoot` (validated against specify CLI 0.11.6).
- `DevOpsAgent` model, `FSDevOpsAgentRepository` (`.specify/devops-agents.yaml`), `/api/devops-agents`, `/api/devops/run` (SSE, with a missing-extension pre-check).
- `runDevOps` on the runner — mirrors the persona path, injects `SPECKIT_DEVOPS_*` env.
- Roster section + editor modal in the **Agents** panel; run buttons live in the Executions view.

## Executions view + persistent history

- Append-only `ExecutionHistory` store (`.specify/.runtime/executions.jsonl` + per-run `logs/<id>.log`), merged by id, deterministic ordering via a monotonic `seq`.
- `WorkflowService` records **every** phase, persona, and devops run: start/finish timestamps, exit code, cost, and a teed log.
- `/api/executions` (+ `/log`); the state watcher now also emits on `executions.jsonl` for live refresh.
- New **Executions** view (3rd Workflow toggle): a list of all runs with status / start / duration / cost / tokens / exit code, drillable to each run's saved log — plus an **agent-centric force-directed graph** (`@xyflow/react` + `d3-force`) with full-screen maximize.

> Note: spec-agent hook runs execute inside the specify CLI subprocess, so they aren't timed individually — they surface via the specification phase run + their `spec-reviews/` outputs.

## Plumbing / prior commits in this branch

- `specify` CLI installer: venv-first resolution (`.venv`/`venv`/`env` or `$VIRTUAL_ENV`), global `uv tool install` fallback; surfaced in the Extensions panel.
- Renamed bundled commands to the required namespace: `speckit.review.*` → `speckit.personas.*`, `speckit.spec.*` → `speckit.spec-agents.*` (+ all references and tests).

## Verification

- `pnpm test` — **132 passing** (added `FSDevOpsAgentRepository` + `FSExecutionHistory` suites; updated `WorkflowService` mock).
- `pnpm run build` — Next build clean (22 routes incl. 4 new) + CLI bin `tsc` clean.
- Bundled extensions install cleanly against `specify` 0.11.6.

## Notes

- Bumps version to **0.4.0**; README updated (features + workspace anatomy).
- New `src/lib/` build output added to `.gitignore` (`/bin/lib/`).
